### PR TITLE
Fix KubeRay integration

### DIFF
--- a/doc/deploy/deployment.md
+++ b/doc/deploy/deployment.md
@@ -97,7 +97,7 @@ or
 ```
 ### 2. Navigate to the Helm Deployment Directory.
 ```
-cd multi-cluster-app-wrapper/deployment
+cd multi-cluster-app-dispatcher/deployment
 ```
 
 ### 3. Run the installation using Helm.

--- a/doc/usage/examples/kuberay/config/xqueuejob-controller.yaml
+++ b/doc/usage/examples/kuberay/config/xqueuejob-controller.yaml
@@ -5,13 +5,10 @@ metadata:
     meta.helm.sh/release-name: mcad
     meta.helm.sh/release-namespace: kube-system
     rbac.authorization.kubernetes.io/autoupdate: "true"
-  creationTimestamp: "2022-09-26T14:38:29Z"
   labels:
     app.kubernetes.io/managed-by: Helm
     kubernetes.io/bootstrapping: rbac-defaults
   name: system:controller:xqueuejob-controller
-  resourceVersion: "516188"
-  uid: cff865b6-db8f-4bf5-ae28-c281e5599b91
 rules:
 - apiGroups:
   - mcad.ibm.com


### PR DESCRIPTION
`xqueuejob-controller.yaml` should not include `resourceVersion`. `resourceVersion` is maintained by Kubernetes APIServer and used to implement Kubernetes's optimistic concurrency control. With `resourceVersion`, the clusterrole may not be able to update.

In addition, is it possible to add more instructions and expected results of every step in [kuberay-mcad.md](https://github.com/project-codeflare/multi-cluster-app-dispatcher/blob/quota-management/doc/usage/examples/kuberay/kuberay-mcad.md)? It is hard for users who do not know MCAD to follow the document.