### PR TITLE
remove invalid characters from branch name an replace with -

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ endif
 # Check for current branch name
 ifneq ($(strip $(GIT_BRANCH)),)
 	TAG:=${TAG}${GIT_BRANCH}-
+
+# 	replace invalid characters that might exist in the branch name
+	TAG:=$(shell echo ${TAG} | sed 's/[^a-zA-Z0-9]/-/g')
 endif
 TAG:=${TAG}${RELEASE_VER}
 


### PR DESCRIPTION
this will also replace . and _, which are valid tag characters, with -. Let me know if this should also be changed.