### PR TITLE
Add kustomization.yaml file for CRDs

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - bases/ibm.com_quotasubtree-v1.yaml
+  - bases/mcad.ibm.com_appwrappers.yaml
+  - bases/mcad.ibm.com_queuejobs.yaml
+  - bases/mcad.ibm.com_schedulingspecs.yaml


### PR DESCRIPTION
This enables downstream projects to consume MCAD CRDs directly with Kustomize, for instance project-codeflare/codeflare-operator#116.