### PR TITLE
Update TAG Generation Logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,11 @@ ifneq ($(strip $(GIT_BRANCH)),)
 # 	replace invalid characters that might exist in the branch name
 	TAG:=$(shell echo ${TAG} | sed 's/[^a-zA-Z0-9]/-/g')
 endif
-TAG:=${TAG}${RELEASE_VER}
+
+# Check if the string does not contain "release"
+ifeq (,$(findstring release,$(GIT_BRANCH)))
+  TAG:=${TAG}${RELEASE_VER}
+endif
 
 .PHONY: print-global-variables
 


### PR DESCRIPTION
The Tag generation logic currently results in the image having a tag like the following:

release-v1.30.0-v.1.30.0

This is as we use both the release branch name and the tag name. What we have previously done to get around this is manually edit the tags once pushed up to Quay. This commit introduces a change such that the generated tag matches the release branch exactly. I think this can be a precursor to us getting rid of the VERSION file altogether.

cc @Maxusmusti 