### PR TITLE
Additional steps for a local KIND cluster

### DIFF
--- a/test/perf-test/node.yaml
+++ b/test/perf-test/node.yaml
@@ -22,10 +22,12 @@ spec:
 status:
   allocatable:
     cpu: 32
+    nvidia.com/gpu: 32
     memory: 256Gi
     pods: 110
   capacity:
     cpu: 32
+    nvidia.com/gpu: 32
     memory: 256Gi
     pods: 110
   nodeInfo:


### PR DESCRIPTION
This PR addresses a few items I noticed that were mistakes or missing in the original KWOK files.
1. Fixed a minor typo of "NCAD" instead of "MCAD"
2. I should add GPU as a default in the node.yaml setup, instead of making people have to add it in manually.
3. Adjusted the helm install instructions to use the tag stable instead of an out-of date tag.
4. Added the missing steps to install KWOK on a KIND cluster