### PR TITLE
fix double counting when AWs dont have any pods running

### DIFF
--- a/config/crd/bases/mcad.ibm.com_appwrappers.yaml
+++ b/config/crd/bases/mcad.ibm.com_appwrappers.yaml
@@ -795,6 +795,18 @@ spec:
                 type: boolean
               message:
                 type: string
+              totalcpu:
+                description: The number of cpu consumed by all pods belonging to an appwrapper.
+                format: int32
+                type: integer
+              totalmemory:
+                description: The amount of memory consumed by all pods belonging to an appwrapper.
+                format: int32
+                type: integer
+              totalgpu:
+                description: The total number of GPUs consumed by all pods belonging to an appwrapper.
+                format: int32
+                type: integer
               pending:
                 description: The number of pending pods.
                 format: int32

--- a/deployment/mcad-controller/crds/mcad.ibm.com_appwrappers.yaml
+++ b/deployment/mcad-controller/crds/mcad.ibm.com_appwrappers.yaml
@@ -795,6 +795,18 @@ spec:
                 type: boolean
               message:
                 type: string
+              totalcpu:
+                description: The number of cpu consumed by all pods belonging to an appwrapper.
+                format: int32
+                type: integer
+              totalmemory:
+                description: The amount of memory consumed by all pods belonging to an appwrapper.
+                format: int32
+                type: integer
+              totalgpu:
+                description: The total number of GPUs consumed by all pods belonging to an appwrapper.
+                format: int32
+                type: integer
               pending:
                 description: The number of pending pods.
                 format: int32

--- a/deployment/mcad-operator/helm-charts/mcad-controller/templates/deployment.yaml
+++ b/deployment/mcad-operator/helm-charts/mcad-controller/templates/deployment.yaml
@@ -7762,6 +7762,18 @@ spec:
                 type: boolean
               message:
                 type: string
+              totalcpu:
+                description: The number of cpu consumed by all pods belonging to an appwrapper.
+                format: int32
+                type: integer
+              totalmemory:
+                description: The amount of memory consumed by all pods belonging to an appwrapper.
+                format: int32
+                type: integer
+              totalgpu:
+                description: The total number of GPUs consumed by all pods belonging to an appwrapper.
+                format: int32
+                type: integer
               pending:
                 description: The number of pending pods.
                 format: int32

--- a/pkg/apis/controller/v1beta1/appwrapper.go
+++ b/pkg/apis/controller/v1beta1/appwrapper.go
@@ -263,6 +263,14 @@ type AppWrapperStatus struct {
 
 	// Represents the latest available observations of pods under appwrapper
 	PendingPodConditions []PendingPodSpec `json:"pendingpodconditions"`
+
+	//Resources consumed
+
+	TotalCPU float64 `json:"totalcpu,omitempty"`
+
+	TotalMemory float64 `json:"totalmemory,omitempty"`
+
+	TotalGPU int64 `json:"totalgpu,omitempty"`
 }
 
 type AppWrapperState string

--- a/pkg/controller/clusterstate/cache/cache.go
+++ b/pkg/controller/clusterstate/cache/cache.go
@@ -33,10 +33,11 @@ package cache
 import (
 	"context"
 	"fmt"
-	"github.com/golang/protobuf/proto"
-	dto "github.com/prometheus/client_model/go"
 	"sync"
 	"time"
+
+	"github.com/golang/protobuf/proto"
+	dto "github.com/prometheus/client_model/go"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -210,7 +211,6 @@ func (sc *ClusterStateCache) GetUnallocatedResources() *api.Resource {
 	return r.Add(sc.availableResources)
 }
 
-
 func (sc *ClusterStateCache) GetUnallocatedHistograms() map[string]*dto.Metric {
 	sc.Mutex.Lock()
 	defer sc.Mutex.Unlock()
@@ -238,7 +238,7 @@ func (sc *ClusterStateCache) GetResourceCapacities() *api.Resource {
 
 // Save the cluster state.
 func (sc *ClusterStateCache) saveState(available *api.Resource, capacity *api.Resource,
-								availableHistogram *api.ResourceHistogram) error {
+	availableHistogram *api.ResourceHistogram) error {
 	klog.V(12).Infof("Saving Cluster State")
 
 	sc.Mutex.Lock()
@@ -261,7 +261,7 @@ func (sc *ClusterStateCache) updateState() error {
 	idleMin := api.EmptyResource()
 	idleMax := api.EmptyResource()
 
-	firstNode :=  true
+	firstNode := true
 	for _, value := range cluster.Nodes {
 		// Do not use any Unschedulable nodes in calculations
 		if value.Unschedulable == true {
@@ -277,12 +277,12 @@ func (sc *ClusterStateCache) updateState() error {
 		// Collect Min and Max for histogram
 		if firstNode {
 			idleMin.MilliCPU = idle.MilliCPU
-			idleMin.Memory   = idle.Memory
-			idleMin.GPU      = idle.GPU
+			idleMin.Memory = idle.Memory
+			idleMin.GPU = idle.GPU
 
 			idleMax.MilliCPU = idle.MilliCPU
-			idleMax.Memory   = idle.Memory
-			idleMax.GPU      = idle.GPU
+			idleMax.Memory = idle.Memory
+			idleMax.GPU = idle.GPU
 			firstNode = false
 		} else {
 			if value.Idle.MilliCPU < idleMin.MilliCPU {
@@ -293,7 +293,7 @@ func (sc *ClusterStateCache) updateState() error {
 
 			if value.Idle.Memory < idleMin.Memory {
 				idleMin.Memory = value.Idle.Memory
-			} else if value.Idle.Memory > idleMax.Memory{
+			} else if value.Idle.Memory > idleMax.Memory {
 				idleMax.Memory = value.Idle.Memory
 			}
 
@@ -354,7 +354,7 @@ func (sc *ClusterStateCache) processCleanupJob() error {
 
 			if api.JobTerminated(job) {
 				delete(sc.Jobs, job.UID)
-				klog.V(3).Infof("[processCleanupJob] Job <%v:%v/%v> was deleted.", job.UID, job.Namespace, job.Name)
+				klog.V(10).Infof("[processCleanupJob] Job <%v:%v/%v> was deleted.", job.UID, job.Namespace, job.Name)
 			} else {
 				// Retry
 				sc.deleteJob(job)
@@ -432,7 +432,7 @@ func (sc *ClusterStateCache) Snapshot() *api.ClusterInfo {
 		// If no scheduling spec, does not handle it.
 		if value.SchedSpec == nil {
 			// Jobs.Tasks are more recognizable than Jobs.UID
-			klog.V(5).Infof("The scheduling spec of Job <%v> with tasks <%+v> is nil, ignore it.", value.UID, value.Tasks)
+			klog.V(10).Infof("The scheduling spec of Job <%v> with tasks <%+v> is nil, ignore it.", value.UID, value.Tasks)
 			continue
 		}
 

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -2171,7 +2171,9 @@ func (cc *XController) manageQueueJob(qj *arbv1.AppWrapper, podPhaseChanges bool
 					updateQj = qj.DeepCopy()
 				}
 				cc.updateEtcd(updateQj, "[syncQueueJob] setCompleted")
-				cc.quotaManager.Release(updateQj)
+				if cc.serverOption.QuotaEnabled {
+					cc.quotaManager.Release(updateQj)
+				}
 			}
 
 			// Bugfix to eliminate performance problem of overloading the event queue.

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -1257,7 +1257,7 @@ func (qjm *XController) ScheduleNext() {
 			klog.Infof("[ScheduleNext] XQJ %s with resources %v to be scheduled on aggregated idle resources %v", qj.Name, aggqj, resources)
 
 			// Assume preemption will remove low priroity AWs in the system, optimistically dispatch such AWs
-			if qjm.nodeChecks(qjm.cache.GetUnallocatedHistograms(), qj) {
+			if !qjm.nodeChecks(qjm.cache.GetUnallocatedHistograms(), qj) {
 				klog.V(4).Infof("[ScheduleNext] Optimistic dispatch for AW %v in namespace %v requesting aggregated resources %v histogram for point in-time fragmented resources are available in the cluster %v", qj.Name, qj.Namespace, qjm.GetAggregatedResources(qj), qjm.cache.GetUnallocatedHistograms())
 			}
 			if aggqj.LessEqual(resources) {

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -915,20 +915,11 @@ func (qjm *XController) getAggregatedAvailableResourcesPriority(unallocatedClust
 				klog.V(10).Infof("[getAggAvaiResPri] %s: Added %s to candidate preemptable job with priority %f.", time.Now().String(), value.Name, value.Status.SystemPriority)
 			}
 
-			for _, resctrl := range qjm.qjobResControls {
-				qjv := resctrl.GetAggregatedResources(value)
-				//only add resources when AWs are truly running
-				if value.Status.State == arbv1.AppWrapperStateActive && value.Status.QueueJobState == arbv1.AppWrapperConditionType(arbv1.AppWrapperStateActive) {
-					preemptable = preemptable.Add(qjv)
-				}
-			}
-			for _, genericItem := range value.Spec.AggrResources.GenericItems {
-				qjv, _ := genericresource.GetResources(&genericItem)
-				//only add resources when AWs are truly running
-				if value.Status.State == arbv1.AppWrapperStateActive && value.Status.QueueJobState == arbv1.AppWrapperConditionType(arbv1.AppWrapperStateActive) {
-					preemptable = preemptable.Add(qjv)
-				}
-			}
+			totalResource := clusterstateapi.EmptyResource()
+			totalResource.GPU = value.Status.TotalGPU
+			totalResource.MilliCPU = value.Status.TotalCPU
+			totalResource.Memory = value.Status.TotalMemory
+			preemptable = preemptable.Add(totalResource)
 
 			continue
 		} else if qjm.isDispatcher {
@@ -1265,117 +1256,117 @@ func (qjm *XController) ScheduleNext() {
 				qjm.cache.GetUnallocatedResources(), priorityindex, qj, "")
 			klog.Infof("[ScheduleNext] XQJ %s with resources %v to be scheduled on aggregated idle resources %v", qj.Name, aggqj, resources)
 
-			// either AW fits inside a node with histogram check or has enough low priority AWs to dispatch
+			// Assume preemption will remove low priroity AWs in the system, optimistically dispatch such AWs
 			if qjm.nodeChecks(qjm.cache.GetUnallocatedHistograms(), qj) {
-
-				if aggqj.LessEqual(resources) || aggqj.LessEqual(resources) && len(proposedPreemptions) > 0 {
-					// Now evaluate quota
-					fits := true
-					klog.V(4).Infof("[ScheduleNext] HOL available resourse successful check for %s at %s activeQ=%t Unsched=%t &qj=%p Version=%s Status=%+v due to quota limits", qj.Name, time.Now().Sub(HOLStartTime), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj), qj, qj.ResourceVersion, qj.Status)
-					if qjm.serverOption.QuotaEnabled {
-						if qjm.quotaManager != nil {
-							// Quota tree design:
-							// - All AppWrappers without quota submission will consume quota from the 'default' node.
-							// - All quota trees in the system should have a 'default' node so AppWrappers without
-							//   quota specification can be dispatched
-							// - If the AppWrapper doesn't have a quota label, then one is added for every tree with the 'default' value
-							// - Depending on how the 'default' node is configured, AppWrappers that don't specify quota could be
-							//   preemptable by default (e.g., 'default' node with 'cpu: 0m' and 'memory: 0Mi' quota and 'hardLimit: false'
-							//   such node borrows quota from other nodes already in the system)
-							apiCacheAWJob, err := qjm.queueJobLister.AppWrappers(qj.Namespace).Get(qj.Name)
-							if err != nil {
-								klog.Errorf("[ScheduleNext] Failed to get AppWrapper from API Cache %v/%v: %v",
-									qj.Namespace, qj.Name, err)
-								continue
-							}
-							allTrees := qjm.quotaManager.GetValidQuotaLabels()
-							newLabels := make(map[string]string)
-							for key, value := range apiCacheAWJob.Labels {
-								newLabels[key] = value
-							}
-							updateLabels := false
-							for _, treeName := range allTrees {
-								if _, quotaSetForAW := newLabels[treeName]; !quotaSetForAW {
-									newLabels[treeName] = "default"
-									updateLabels = true
-								}
-							}
-							if updateLabels {
-								apiCacheAWJob.SetLabels(newLabels)
-								if err := qjm.updateEtcd(apiCacheAWJob, "ScheduleNext - setDefaultQuota"); err == nil {
-									klog.V(3).Infof("[ScheduleNext] Default quota added to AW %v", qj.Name)
-								} else {
-									klog.V(3).Infof("[ScheduleNext] Failed to added default quota to AW %v, skipping dispatch of AW", qj.Name)
-									return
-								}
-							}
-							var msg string
-							var preemptAWs []*arbv1.AppWrapper
-							quotaFits, preemptAWs, msg = qjm.quotaManager.Fits(qj, aggqj, proposedPreemptions)
-							if quotaFits {
-								klog.Infof("[ScheduleNext] HOL quota evaluation successful %s for %s activeQ=%t Unsched=%t &qj=%p Version=%s Status=%+v due to quota limits", qj.Name, time.Now().Sub(HOLStartTime), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj), qj, qj.ResourceVersion, qj.Status)
-								// Set any jobs that are marked for preemption
-								qjm.preemptAWJobs(preemptAWs)
-							} else { // Not enough free quota to dispatch appwrapper
-								dispatchFailedMessage = "Insufficient quota to dispatch AppWrapper."
-								if len(msg) > 0 {
-									dispatchFailedReason += " "
-									dispatchFailedReason += msg
-								}
-								klog.V(3).Infof("[ScheduleNext] HOL Blocking by %s for %s activeQ=%t Unsched=%t &qj=%p Version=%s Status=%+v msg=%s, due to quota limits",
-									qj.Name, time.Now().Sub(HOLStartTime), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj), qj, qj.ResourceVersion, qj.Status, msg)
-							}
-							fits = quotaFits
-						} else {
-							fits = false
-							//Quota manager not initialized
-							dispatchFailedMessage = "Quota evaluation is enabled but not initialized. Insufficient quota to dispatch AppWrapper."
-							klog.Errorf("[ScheduleNext] Quota evaluation is enabled but not initialized.  AppWrapper %s/%s does not have enough quota\n", qj.Name, qj.Namespace)
+				klog.V(4).Infof("[ScheduleNext] Optimistic dispatch for AW %v in namespace %v requesting aggregated resources %v histogram for point in-time fragmented resources are available in the cluster %v", qj.Name, qj.Namespace, qjm.GetAggregatedResources(qj), qjm.cache.GetUnallocatedHistograms())
+			}
+			if aggqj.LessEqual(resources) {
+				// Now evaluate quota
+				fits := true
+				klog.V(4).Infof("[ScheduleNext] HOL available resourse successful check for %s at %s activeQ=%t Unsched=%t &qj=%p Version=%s Status=%+v due to quota limits", qj.Name, time.Now().Sub(HOLStartTime), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj), qj, qj.ResourceVersion, qj.Status)
+				if qjm.serverOption.QuotaEnabled {
+					if qjm.quotaManager != nil {
+						// Quota tree design:
+						// - All AppWrappers without quota submission will consume quota from the 'default' node.
+						// - All quota trees in the system should have a 'default' node so AppWrappers without
+						//   quota specification can be dispatched
+						// - If the AppWrapper doesn't have a quota label, then one is added for every tree with the 'default' value
+						// - Depending on how the 'default' node is configured, AppWrappers that don't specify quota could be
+						//   preemptable by default (e.g., 'default' node with 'cpu: 0m' and 'memory: 0Mi' quota and 'hardLimit: false'
+						//   such node borrows quota from other nodes already in the system)
+						apiCacheAWJob, err := qjm.queueJobLister.AppWrappers(qj.Namespace).Get(qj.Name)
+						if err != nil {
+							klog.Errorf("[ScheduleNext] Failed to get AppWrapper from API Cache %v/%v: %v",
+								qj.Namespace, qj.Name, err)
+							continue
 						}
+						allTrees := qjm.quotaManager.GetValidQuotaLabels()
+						newLabels := make(map[string]string)
+						for key, value := range apiCacheAWJob.Labels {
+							newLabels[key] = value
+						}
+						updateLabels := false
+						for _, treeName := range allTrees {
+							if _, quotaSetForAW := newLabels[treeName]; !quotaSetForAW {
+								newLabels[treeName] = "default"
+								updateLabels = true
+							}
+						}
+						if updateLabels {
+							apiCacheAWJob.SetLabels(newLabels)
+							if err := qjm.updateEtcd(apiCacheAWJob, "ScheduleNext - setDefaultQuota"); err == nil {
+								klog.V(3).Infof("[ScheduleNext] Default quota added to AW %v", qj.Name)
+							} else {
+								klog.V(3).Infof("[ScheduleNext] Failed to added default quota to AW %v, skipping dispatch of AW", qj.Name)
+								return
+							}
+						}
+						var msg string
+						var preemptAWs []*arbv1.AppWrapper
+						quotaFits, preemptAWs, msg = qjm.quotaManager.Fits(qj, aggqj, proposedPreemptions)
+						if quotaFits {
+							klog.Infof("[ScheduleNext] HOL quota evaluation successful %s for %s activeQ=%t Unsched=%t &qj=%p Version=%s Status=%+v due to quota limits", qj.Name, time.Now().Sub(HOLStartTime), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj), qj, qj.ResourceVersion, qj.Status)
+							// Set any jobs that are marked for preemption
+							qjm.preemptAWJobs(preemptAWs)
+						} else { // Not enough free quota to dispatch appwrapper
+							dispatchFailedMessage = "Insufficient quota to dispatch AppWrapper."
+							if len(msg) > 0 {
+								dispatchFailedReason += " "
+								dispatchFailedReason += msg
+							}
+							klog.V(3).Infof("[ScheduleNext] HOL Blocking by %s for %s activeQ=%t Unsched=%t &qj=%p Version=%s Status=%+v msg=%s, due to quota limits",
+								qj.Name, time.Now().Sub(HOLStartTime), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj), qj, qj.ResourceVersion, qj.Status, msg)
+						}
+						fits = quotaFits
 					} else {
-						klog.V(4).Infof("[ScheduleNext] HOL quota evaluation not enabled for %s at %s activeQ=%t Unsched=%t &qj=%p Version=%s Status=%+v", qj.Name, time.Now().Sub(HOLStartTime), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj), qj, qj.ResourceVersion, qj.Status)
+						fits = false
+						//Quota manager not initialized
+						dispatchFailedMessage = "Quota evaluation is enabled but not initialized. Insufficient quota to dispatch AppWrapper."
+						klog.Errorf("[ScheduleNext] Quota evaluation is enabled but not initialized.  AppWrapper %s/%s does not have enough quota\n", qj.Name, qj.Namespace)
 					}
-
-					// If quota evalauation sucedeed or quota evaluation not enabled set the appwrapper to be dispatched
-					if fits {
-						// aw is ready to go!
-						apiQueueJob, e := qjm.queueJobLister.AppWrappers(qj.Namespace).Get(qj.Name)
-						// apiQueueJob's ControllerFirstTimestamp is only microsecond level instead of nanosecond level
-						if e != nil {
-							klog.Errorf("[ScheduleNext] Unable to get AW %s from API cache &aw=%p Version=%s Status=%+v err=%#v", qj.Name, qj, qj.ResourceVersion, qj.Status, err)
-							if qjm.quotaManager != nil && quotaFits {
-								//Quota was allocated for this appwrapper, release it.
-								qjm.quotaManager.Release(qj)
-							}
-							return
-						}
-						// make sure qj has the latest information
-						if larger(apiQueueJob.ResourceVersion, qj.ResourceVersion) {
-							klog.V(4).Infof("[ScheduleNext] %s found more recent copy from cache          &qj=%p          qj=%+v", qj.Name, qj, qj)
-							klog.V(4).Infof("[ScheduleNext] %s found more recent copy from cache &apiQueueJob=%p apiQueueJob=%+v", apiQueueJob.Name, apiQueueJob, apiQueueJob)
-							apiQueueJob.DeepCopyInto(qj)
-						}
-						desired := int32(0)
-						for i, ar := range qj.Spec.AggrResources.Items {
-							desired += ar.Replicas
-							qj.Spec.AggrResources.Items[i].AllocatedReplicas = ar.Replicas
-						}
-						qj.Status.CanRun = true
-						qj.Status.FilterIgnore = true // update CanRun & Spec.  no need to trigger event
-						// Handle k8s watch race condition
-						if err := qjm.updateEtcd(qj, "ScheduleNext - setCanRun"); err == nil {
-							// add to eventQueue for dispatching to Etcd
-							if err = qjm.eventQueue.Add(qj); err != nil { // unsuccessful add to eventQueue, add back to activeQ
-								klog.Errorf("[ScheduleNext] Fail to add %s to eventQueue, activeQ.Add_toSchedulingQueue &qj=%p Version=%s Status=%+v err=%#v", qj.Name, qj, qj.ResourceVersion, qj.Status, err)
-								qjm.qjqueue.MoveToActiveQueueIfExists(qj)
-							} else { // successful add to eventQueue, remove from qjqueue
-								qjm.qjqueue.Delete(qj)
-								forwarded = true
-								klog.V(4).Infof("[ScheduleNext] %s Delay=%.6f seconds eventQueue.Add_afterHeadOfLine activeQ=%t, Unsched=%t &aw=%p Version=%s Status=%+v", qj.Name, time.Now().Sub(qj.Status.ControllerFirstTimestamp.Time).Seconds(), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj), qj, qj.ResourceVersion, qj.Status)
-							}
-						} //updateEtcd
-					} //fits
+				} else {
+					klog.V(4).Infof("[ScheduleNext] HOL quota evaluation not enabled for %s at %s activeQ=%t Unsched=%t &qj=%p Version=%s Status=%+v", qj.Name, time.Now().Sub(HOLStartTime), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj), qj, qj.ResourceVersion, qj.Status)
 				}
+
+				// If quota evalauation sucedeed or quota evaluation not enabled set the appwrapper to be dispatched
+				if fits {
+					// aw is ready to go!
+					apiQueueJob, e := qjm.queueJobLister.AppWrappers(qj.Namespace).Get(qj.Name)
+					// apiQueueJob's ControllerFirstTimestamp is only microsecond level instead of nanosecond level
+					if e != nil {
+						klog.Errorf("[ScheduleNext] Unable to get AW %s from API cache &aw=%p Version=%s Status=%+v err=%#v", qj.Name, qj, qj.ResourceVersion, qj.Status, err)
+						if qjm.quotaManager != nil && quotaFits {
+							//Quota was allocated for this appwrapper, release it.
+							qjm.quotaManager.Release(qj)
+						}
+						return
+					}
+					// make sure qj has the latest information
+					if larger(apiQueueJob.ResourceVersion, qj.ResourceVersion) {
+						klog.V(4).Infof("[ScheduleNext] %s found more recent copy from cache          &qj=%p          qj=%+v", qj.Name, qj, qj)
+						klog.V(4).Infof("[ScheduleNext] %s found more recent copy from cache &apiQueueJob=%p apiQueueJob=%+v", apiQueueJob.Name, apiQueueJob, apiQueueJob)
+						apiQueueJob.DeepCopyInto(qj)
+					}
+					desired := int32(0)
+					for i, ar := range qj.Spec.AggrResources.Items {
+						desired += ar.Replicas
+						qj.Spec.AggrResources.Items[i].AllocatedReplicas = ar.Replicas
+					}
+					qj.Status.CanRun = true
+					qj.Status.FilterIgnore = true // update CanRun & Spec.  no need to trigger event
+					// Handle k8s watch race condition
+					if err := qjm.updateEtcd(qj, "ScheduleNext - setCanRun"); err == nil {
+						// add to eventQueue for dispatching to Etcd
+						if err = qjm.eventQueue.Add(qj); err != nil { // unsuccessful add to eventQueue, add back to activeQ
+							klog.Errorf("[ScheduleNext] Fail to add %s to eventQueue, activeQ.Add_toSchedulingQueue &qj=%p Version=%s Status=%+v err=%#v", qj.Name, qj, qj.ResourceVersion, qj.Status, err)
+							qjm.qjqueue.MoveToActiveQueueIfExists(qj)
+						} else { // successful add to eventQueue, remove from qjqueue
+							qjm.qjqueue.Delete(qj)
+							forwarded = true
+							klog.V(4).Infof("[ScheduleNext] %s Delay=%.6f seconds eventQueue.Add_afterHeadOfLine activeQ=%t, Unsched=%t &aw=%p Version=%s Status=%+v", qj.Name, time.Now().Sub(qj.Status.ControllerFirstTimestamp.Time).Seconds(), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj), qj, qj.ResourceVersion, qj.Status)
+						}
+					} //updateEtcd
+				} //fits
 			} else { // Not enough free resources to dispatch HOL
 				dispatchFailedMessage = "Insufficient resources to dispatch AppWrapper."
 				klog.V(4).Infof("[ScheduleNext] HOL Blocking by %s for %s activeQ=%t Unsched=%t &qj=%p Version=%s Status=%+v", qj.Name, time.Now().Sub(HOLStartTime), qjm.qjqueue.IfExistActiveQ(qj), qjm.qjqueue.IfExistUnschedulableQ(qj), qj, qj.ResourceVersion, qj.Status)

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -921,7 +921,10 @@ func (qjm *XController) getAggregatedAvailableResourcesPriority(unallocatedClust
 			}
 			for _, genericItem := range value.Spec.AggrResources.GenericItems {
 				qjv, _ := genericresource.GetResources(&genericItem)
-				preemptable = preemptable.Add(qjv)
+				//only add resources when AWs are truly running
+				if value.Status.State == arbv1.AppWrapperStateActive && value.Status.QueueJobState == arbv1.AppWrapperConditionType(arbv1.AppWrapperStateActive) {
+					preemptable = preemptable.Add(qjv)
+				}
 			}
 
 			continue

--- a/pkg/controller/queuejobresources/pod/pod.go
+++ b/pkg/controller/queuejobresources/pod/pod.go
@@ -243,6 +243,7 @@ func (qjrPod *QueueJobResPod) UpdateQueueJobStatus(queuejob *arbv1.AppWrapper) e
 	}
 
 	running := int32(queuejobresources.FilterPods(pods, v1.PodRunning))
+	totalResourcesConsumed := queuejobresources.GetPodResourcesByPhase(v1.PodRunning, pods)
 	pending := int32(queuejobresources.FilterPods(pods, v1.PodPending))
 	succeeded := int32(queuejobresources.FilterPods(pods, v1.PodSucceeded))
 	failed := int32(queuejobresources.FilterPods(pods, v1.PodFailed))
@@ -254,6 +255,10 @@ func (qjrPod *QueueJobResPod) UpdateQueueJobStatus(queuejob *arbv1.AppWrapper) e
 	queuejob.Status.Running = running
 	queuejob.Status.Succeeded = succeeded
 	queuejob.Status.Failed = failed
+	//Total resources by all running pods
+	queuejob.Status.TotalGPU = totalResourcesConsumed.GPU
+	queuejob.Status.TotalCPU = totalResourcesConsumed.MilliCPU
+	queuejob.Status.TotalMemory = totalResourcesConsumed.Memory
 
 	queuejob.Status.PendingPodConditions = nil
 	for podName, cond := range podsConditionMap {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1102,7 +1102,6 @@ func createDeploymentAWwith550CPU(context *context, name string) *arbv1.AppWrapp
 			"metadata": {
 				"labels": {
 					"app": "aw-deployment-2-550cpu"
-					"appwrapper.mcad.ibm.com": "aw-deployment-2-550cpu"
 				},
 				"annotations": {
 					"appwrapper.mcad.ibm.com/appwrapper-name": "aw-deployment-2-550cpu"

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1102,6 +1102,7 @@ func createDeploymentAWwith550CPU(context *context, name string) *arbv1.AppWrapp
 			"metadata": {
 				"labels": {
 					"app": "aw-deployment-2-550cpu"
+					"appwrapper.mcad.ibm.com": "aw-deployment-2-550cpu"
 				},
 				"annotations": {
 					"appwrapper.mcad.ibm.com/appwrapper-name": "aw-deployment-2-550cpu"


### PR DESCRIPTION
When AWs are running with no pods under it, there is a double counting of resources
![Screenshot 2023-06-16 at 1 46 32 PM](https://github.com/project-codeflare/multi-cluster-app-dispatcher/assets/5898557/2abbd12c-60d8-410f-87d7-cf8bbd9b1ae5)

As seen in the screenshot minikube resources are increased in MCAD accounting when AWs are dispatched and do not have any pods running. This will cause queued AWs to dispatch and will never run, the real resources are shown in the terminal section of the screenshot 