### PR TITLE
Expose metrics endpoint

### DIFF
--- a/cmd/kar-controllers/app/generic-server.go
+++ b/cmd/kar-controllers/app/generic-server.go
@@ -103,7 +103,7 @@ func (s *Server) Shutdown() error {
 	if err := s.httpServer.Shutdown(shutdownCtx); err != nil {
 		return fmt.Errorf("failed to shutdown server gracefully: %v", err)
 	}
-	return s.httpServer.Shutdown(shutdownCtx)
+	return nil
 }
 
 // newListener creates a new TCP listener bound to the given address.

--- a/cmd/kar-controllers/app/generic-server.go
+++ b/cmd/kar-controllers/app/generic-server.go
@@ -1,3 +1,33 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/*
+Copyright 2019, 2021 The Multi-Cluster App Dispatcher Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package app
 
 import (

--- a/cmd/kar-controllers/app/generic-server.go
+++ b/cmd/kar-controllers/app/generic-server.go
@@ -1,0 +1,107 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	logger "k8s.io/klog/v2"
+)
+
+type ServerOption func(*Server)
+
+// WithTimeout sets the shutdown timeout for the server.
+func WithTimeout(timeout time.Duration) ServerOption {
+	return func(s *Server) {
+		s.shutdownTimeout = timeout
+	}
+}
+
+type Server struct {
+	httpServer      http.Server
+	listener        net.Listener
+	endpoint        string
+	shutdownTimeout time.Duration
+}
+
+func NewServer(port int, endpoint string, handler http.Handler, options ...ServerOption) (*Server, error) {
+	addr := "0"
+	if port != 0 {
+		addr = ":" + strconv.Itoa(port)
+	}
+
+	listener, err := newListener(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle(endpoint, handler)
+
+	s := &Server{
+		endpoint:        endpoint,
+		listener:        listener,
+		httpServer:      http.Server{Handler: mux},
+		shutdownTimeout: 30 * time.Second,  // Default value
+	}
+
+	for _, opt := range options {
+		opt(s)
+	}
+
+	return s, nil
+}
+
+func (s *Server) Start() (err error) {
+	if s.listener == nil {
+		logger.Infof("Serving endpoint %s is disabled", s.endpoint)
+		return
+	}
+	
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("serving endpoint %s failed: %v", s.endpoint, r)
+		}
+	}()
+	
+	logger.Infof("Started serving endpoint %s at %s", s.endpoint, s.listener.Addr())
+	if e := s.httpServer.Serve(s.listener); e != http.ErrServerClosed {
+		return fmt.Errorf("serving endpoint %s failed: %v", s.endpoint, e)
+	}
+	return
+}
+
+func (s *Server) Shutdown() error {
+	if s.listener == nil {
+		return nil
+	}
+	
+	logger.Info("Stopping server")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Try graceful shutdown
+	if err := s.httpServer.Shutdown(shutdownCtx); err != nil {
+		return fmt.Errorf("failed to shutdown server gracefully: %v", err)
+	}
+	return s.httpServer.Shutdown(shutdownCtx)
+}
+
+// newListener creates a new TCP listener bound to the given address.
+func newListener(addr string) (net.Listener, error) {
+	// Add a case to disable serving altogether
+	if addr == "0" {
+		return nil, nil
+	}
+
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create listener: %v", err)
+	}
+
+	return listener, nil
+}

--- a/cmd/kar-controllers/app/generic-server.go
+++ b/cmd/kar-controllers/app/generic-server.go
@@ -13,21 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-/*
-Copyright 2019, 2021 The Multi-Cluster App Dispatcher Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package app
 
 import (
@@ -109,9 +94,9 @@ func (s *Server) Shutdown() error {
 		return nil
 	}
 	
-	logger.Info("Stopping server")
+	logger.Infof("Shutting down endpoint %s at %s (gracefully waiting for %s)", s.endpoint, s.listener.Addr(), s.shutdownTimeout)
 
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), s.shutdownTimeout)
 	defer cancel()
 
 	// Try graceful shutdown

--- a/cmd/kar-controllers/app/metrics/prom-metrics.go
+++ b/cmd/kar-controllers/app/metrics/prom-metrics.go
@@ -1,0 +1,26 @@
+package metrics
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// Global Prometheus Registry
+var globalPromRegistry = prometheus.NewRegistry()
+
+// metricsHandler returns a http.Handler that serves the prometheus metrics
+func PrometheusHandler() http.Handler {
+	// Add Go module build info.
+	globalPromRegistry.MustRegister(collectors.NewBuildInfoCollector())
+	globalPromRegistry.MustRegister(collectors.NewGoCollector())
+	globalPromRegistry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+
+	handlerOpts := promhttp.HandlerOpts{
+		ErrorHandling: promhttp.HTTPErrorOnError,
+	}
+
+	return promhttp.HandlerFor(globalPromRegistry, handlerOpts)
+}

--- a/cmd/kar-controllers/app/options/options.go
+++ b/cmd/kar-controllers/app/options/options.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	klog "k8s.io/klog/v2"
 )
 
 // ServerOption is the main context object for the controller manager.
@@ -38,9 +40,9 @@ type ServerOption struct {
 	HeadOfLineHoldingTime              int
 	QuotaEnabled                       bool // Controller is to evaluate quota per request
 	QuotaRestURL                       string
-	HealthProbeListenAddr              string
+	HealthProbeListenPort				int  
 	DispatchResourceReservationTimeout int64
-	MetricsListenAddr    string
+	MetricsListenPort                  int 
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -65,9 +67,9 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&s.QuotaEnabled, "quotaEnabled", s.QuotaEnabled, "Enable quota policy evaluation.  Default is false.")
 	fs.StringVar(&s.QuotaRestURL, "quotaURL", s.QuotaRestURL, "URL for ReST quota management.  Default is none.")
 	fs.IntVar(&s.SecurePort, "secure-port", 6443, "The port on which to serve secured, authenticated access for metrics.")
-	fs.StringVar(&s.HealthProbeListenAddr, "healthProbeListenAddr", ":8081", "Listen address for health probes. Defaults to ':8081'")
+	fs.IntVar(&s.HealthProbeListenPort, "healthProbeListenPort", 8081, "Listen port for health probes. Defaults to ':8081'")
 	// using port 8083 for metrics as 8082 is used by `custom-metrics-apiserver`
-	fs.StringVar(&s.MetricsListenAddr, "metricsListenAddr", ":8083", "Listen address for metrics. Defaults to ':8083'")
+	fs.IntVar(&s.MetricsListenPort, "metricsListenPort", 8083, "Listen port for metrics. Defaults to ':8083'")
 	fs.Int64Var(&s.DispatchResourceReservationTimeout, "dispatchResourceReservationTimeout", s.DispatchResourceReservationTimeout, "Resource reservation timeout for pods to be created once AppWrapper is dispatched, in millisecond.  Defaults to '300000', 5 minutes")
 }
 

--- a/cmd/kar-controllers/app/options/options.go
+++ b/cmd/kar-controllers/app/options/options.go
@@ -21,8 +21,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-
-	klog "k8s.io/klog/v2"
 )
 
 // ServerOption is the main context object for the controller manager.
@@ -40,9 +38,9 @@ type ServerOption struct {
 	HeadOfLineHoldingTime              int
 	QuotaEnabled                       bool // Controller is to evaluate quota per request
 	QuotaRestURL                       string
-	HealthProbeListenPort				int  
+	HealthProbeListenPort              int
 	DispatchResourceReservationTimeout int64
-	MetricsListenPort                  int 
+	MetricsListenPort                  int
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -68,8 +66,8 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&s.QuotaRestURL, "quotaURL", s.QuotaRestURL, "URL for ReST quota management.  Default is none.")
 	fs.IntVar(&s.SecurePort, "secure-port", 6443, "The port on which to serve secured, authenticated access for metrics.")
 	fs.IntVar(&s.HealthProbeListenPort, "healthProbeListenPort", 8081, "Listen port for health probes. Defaults to ':8081'")
-	// using port 8083 for metrics as 8082 is used by `custom-metrics-apiserver`
-	fs.IntVar(&s.MetricsListenPort, "metricsListenPort", 8083, "Listen port for metrics. Defaults to ':8083'")
+	// using port 9090 for metrics as 8082 is used by `custom-metrics-apiserver`
+	fs.IntVar(&s.MetricsListenPort, "metricsListenPort", 9090, "Listen port for metrics. Defaults to ':9090'")
 	fs.Int64Var(&s.DispatchResourceReservationTimeout, "dispatchResourceReservationTimeout", s.DispatchResourceReservationTimeout, "Resource reservation timeout for pods to be created once AppWrapper is dispatched, in millisecond.  Defaults to '300000', 5 minutes")
 }
 

--- a/cmd/kar-controllers/app/options/options.go
+++ b/cmd/kar-controllers/app/options/options.go
@@ -40,6 +40,7 @@ type ServerOption struct {
 	QuotaRestURL                       string
 	HealthProbeListenAddr              string
 	DispatchResourceReservationTimeout int64
+	MetricsListenAddr    string
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -65,6 +66,8 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&s.QuotaRestURL, "quotaURL", s.QuotaRestURL, "URL for ReST quota management.  Default is none.")
 	fs.IntVar(&s.SecurePort, "secure-port", 6443, "The port on which to serve secured, authenticated access for metrics.")
 	fs.StringVar(&s.HealthProbeListenAddr, "healthProbeListenAddr", ":8081", "Listen address for health probes. Defaults to ':8081'")
+	// using port 8083 for metrics as 8082 is used by `custom-metrics-apiserver`
+	fs.StringVar(&s.MetricsListenAddr, "metricsListenAddr", ":8083", "Listen address for metrics. Defaults to ':8083'")
 	fs.Int64Var(&s.DispatchResourceReservationTimeout, "dispatchResourceReservationTimeout", s.DispatchResourceReservationTimeout, "Resource reservation timeout for pods to be created once AppWrapper is dispatched, in millisecond.  Defaults to '300000', 5 minutes")
 }
 

--- a/cmd/kar-controllers/app/options/options.go
+++ b/cmd/kar-controllers/app/options/options.go
@@ -66,7 +66,6 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&s.QuotaRestURL, "quotaURL", s.QuotaRestURL, "URL for ReST quota management.  Default is none.")
 	fs.IntVar(&s.SecurePort, "secure-port", 6443, "The port on which to serve secured, authenticated access for metrics.")
 	fs.IntVar(&s.HealthProbeListenPort, "healthProbeListenPort", 8081, "Listen port for health probes. Defaults to ':8081'")
-	// using port 9090 for metrics as 8082 is used by `custom-metrics-apiserver`
 	fs.IntVar(&s.MetricsListenPort, "metricsListenPort", 9090, "Listen port for metrics. Defaults to ':9090'")
 	fs.Int64Var(&s.DispatchResourceReservationTimeout, "dispatchResourceReservationTimeout", s.DispatchResourceReservationTimeout, "Resource reservation timeout for pods to be created once AppWrapper is dispatched, in millisecond.  Defaults to '300000', 5 minutes")
 }

--- a/cmd/kar-controllers/app/server.go
+++ b/cmd/kar-controllers/app/server.go
@@ -21,8 +21,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 
+	"golang.org/x/sync/errgroup"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -39,6 +39,9 @@ import (
 
 	"github.com/project-codeflare/multi-cluster-app-dispatcher/pkg/config"
 )
+
+// Global Prometheus Registry
+var globalPromRegistry = prometheus.NewRegistry()
 
 func buildConfig(master, kubeconfig string) (*rest.Config, error) {
 	if master != "" || kubeconfig != "" {
@@ -73,23 +76,7 @@ func Run(ctx context.Context, opt *options.ServerOption) error {
 		return fmt.Errorf("failed to create a job controller")
 	}
 
-	stopCh := make(chan struct{})
-    // this channel is used to signal that the job controller is done
-    jobctrlDoneCh := make(chan struct{})
-
-	go func() {
-        defer close(stopCh)
-		<-ctx.Done()
-	}()
-
-	go func() {
-     jobctrl.Run(stopCh)
-    // close the jobctrlDoneCh channel when the job controller is done
-     close(jobctrlDoneCh)
-    }()
-
-    // wait for the job controller to be done before shutting down the server
-    <-jobctrlDoneCh
+	go jobctrl.Run(ctx.Done())
 
 	err = startHealthAndMetricsServers(ctx, opt)
 	if err != nil {
@@ -100,80 +87,49 @@ func Run(ctx context.Context, opt *options.ServerOption) error {
 	return nil
 }
 
-// Starts the health probe listener
-func startHealthAndMetricsServers(ctx context.Context, opt *options.ServerOption) error {
-    
-    // Create a new registry.
-	reg := prometheus.NewRegistry()
-
+// metricsHandler returns a http.Handler that serves the prometheus metrics
+func prometheusHandler() http.Handler {
 	// Add Go module build info.
-	reg.MustRegister(collectors.NewBuildInfoCollector())
-	reg.MustRegister(collectors.NewGoCollector())
-    reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+	globalPromRegistry.MustRegister(collectors.NewBuildInfoCollector())
+	globalPromRegistry.MustRegister(collectors.NewGoCollector())
+	globalPromRegistry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 
-    metricsHandler := http.NewServeMux()
-
-    // Use the HTTPErrorOnError option for the Prometheus handler
 	handlerOpts := promhttp.HandlerOpts{
 		ErrorHandling: promhttp.HTTPErrorOnError,
 	}
 
-	metricsHandler.Handle("/metrics", promhttp.HandlerFor(prometheus.DefaultGatherer, handlerOpts))
+	return promhttp.HandlerFor(globalPromRegistry, handlerOpts)
+}
 
-    healthHandler := http.NewServeMux()
-    healthHandler.Handle("/healthz", &health.Handler{})
+func healthHandler() http.Handler {
+	healthHandler := http.NewServeMux()
+	healthHandler.Handle("/healthz", &health.Handler{})
+	return healthHandler
+}
 
-    metricsServer := &http.Server{
-        Addr:    opt.MetricsListenAddr,
-        Handler: metricsHandler,
-    }
+// Starts the health probe listener
+func startHealthAndMetricsServers(ctx context.Context, opt *options.ServerOption) error {
+	g, ctx := errgroup.WithContext(ctx)
 
-    healthServer := &http.Server{
-        Addr:    opt.HealthProbeListenAddr,
-        Handler: healthHandler,
-    }
+	// metrics server
+	metricsServer, err := NewServer(opt.MetricsListenPort, "/metrics", prometheusHandler())
+	if err != nil {
+		return err
+	}
 
-    // make a channel for errors for each server
-    metricsServerErrChan := make(chan error)
-    healthServerErrChan := make(chan error)
+	healthServer, err := NewServer(opt.HealthProbeListenPort, "/healthz", healthHandler())
+	if err != nil {
+		return err
+	}
 
-    // start servers in their own goroutines
-    go func() {
-        defer close(metricsServerErrChan)
-        err := metricsServer.ListenAndServe()
-        if err != nil && err != http.ErrServerClosed {
-            metricsServerErrChan <- err
-        }
-    }()
+	g.Go(metricsServer.Start)
+	g.Go(healthServer.Start)
 
-    go func() {
-        defer close(healthServerErrChan)
-        err := healthServer.ListenAndServe()
-        if err != nil && err != http.ErrServerClosed {
-            healthServerErrChan <- err
-        }
-    }()
+	go func() {
+		<-ctx.Done()
+		metricsServer.Shutdown()
+		healthServer.Shutdown()
+	}()
 
-    // use select to wait for either a shutdown signal or an error
-    select {
-    case <-ctx.Done():
-        // received an OS shutdown signal, shut down servers gracefully
-        ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-        defer cancel()
-
-  		errM := metricsServer.Shutdown(ctx)
-		if errM != nil {
-			return fmt.Errorf("metrics server shutdown error: %v", errM)
-		}
-   		errH := healthServer.Shutdown(ctx)
-			if errH != nil {
-			return fmt.Errorf("health server shutdown error: %v", errH)
-		}
-    case err := <-metricsServerErrChan:
-        return fmt.Errorf("metrics server error: %v", err)
-    case err := <-healthServerErrChan:
-        return fmt.Errorf("health server error: %v", err)
-    }
-
-    return nil
+	return nil
 }

--- a/cmd/kar-controllers/app/server.go
+++ b/cmd/kar-controllers/app/server.go
@@ -68,10 +68,6 @@ func Run(ctx context.Context, opt *options.ServerOption) error {
 		AgentConfigs: strings.Split(opt.AgentConfigs, ","),
 	}
 
-	jobctrl := queuejob.NewJobController(restConfig, mcadConfig, extConfig)
-	if jobctrl == nil {
-		return fmt.Errorf("failed to create a job controller")
-	}
 
 	g, gCtx := errgroup.WithContext(ctx)
 
@@ -86,8 +82,7 @@ func Run(ctx context.Context, opt *options.ServerOption) error {
 		return err
 	}
 
-	// Create the job controller
-	jobctrl := queuejob.NewJobController(config, opt)
+	jobctrl := queuejob.NewJobController(restConfig, mcadConfig, extConfig)
 	if jobctrl == nil {
 		return fmt.Errorf("failed to create a job controller")
 	}

--- a/cmd/kar-controllers/app/server.go
+++ b/cmd/kar-controllers/app/server.go
@@ -17,19 +17,27 @@ limitations under the License.
 package app
 
 import (
-	"net/http"
 	"strings"
-
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"context"
+	"fmt"
+	"net/http"
+	"time"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/utils/pointer"
 
 	"github.com/project-codeflare/multi-cluster-app-dispatcher/cmd/kar-controllers/app/options"
-	"github.com/project-codeflare/multi-cluster-app-dispatcher/pkg/config"
 	"github.com/project-codeflare/multi-cluster-app-dispatcher/pkg/controller/queuejob"
 	"github.com/project-codeflare/multi-cluster-app-dispatcher/pkg/health"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	"k8s.io/utils/pointer"
+
+	"github.com/project-codeflare/multi-cluster-app-dispatcher/pkg/config"
 )
 
 func buildConfig(master, kubeconfig string) (*rest.Config, error) {
@@ -39,13 +47,11 @@ func buildConfig(master, kubeconfig string) (*rest.Config, error) {
 	return rest.InClusterConfig()
 }
 
-func Run(opt *options.ServerOption) error {
+func Run(ctx context.Context, opt *options.ServerOption) error {
 	restConfig, err := buildConfig(opt.Master, opt.Kubeconfig)
 	if err != nil {
 		return err
 	}
-
-	neverStop := make(chan struct{})
 
 	restConfig.QPS = 100.0
 	restConfig.Burst = 200.0
@@ -64,27 +70,101 @@ func Run(opt *options.ServerOption) error {
 
 	jobctrl := queuejob.NewJobController(restConfig, mcadConfig, extConfig)
 	if jobctrl == nil {
-		return nil
+		return fmt.Errorf("failed to create a job controller")
 	}
-	jobctrl.Run(neverStop)
 
-	// This call is blocking (unless an error occurs) which equates to <-neverStop
-	err = listenHealthProbe(opt)
+	stopCh := make(chan struct{})
+
+	go func() {
+        defer close(stopCh)
+		<-ctx.Done()
+	}()
+
+	go jobctrl.Run(stopCh)
+
+	err = startHealthAndMetricsServers(ctx, opt)
 	if err != nil {
 		return err
 	}
 
+	<-ctx.Done()
 	return nil
 }
 
 // Starts the health probe listener
-func listenHealthProbe(opt *options.ServerOption) error {
-	handler := http.NewServeMux()
-	handler.Handle("/healthz", &health.Handler{})
-	err := http.ListenAndServe(opt.HealthProbeListenAddr, handler)
-	if err != nil {
-		return err
+func startHealthAndMetricsServers(ctx context.Context, opt *options.ServerOption) error {
+    
+    // Create a new registry.
+	reg := prometheus.NewRegistry()
+
+	// Add Go module build info.
+	reg.MustRegister(collectors.NewBuildInfoCollector())
+	reg.MustRegister(collectors.NewGoCollector())
+    reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+
+    metricsHandler := http.NewServeMux()
+
+    // Use the HTTPErrorOnError option for the Prometheus handler
+	handlerOpts := promhttp.HandlerOpts{
+		ErrorHandling: promhttp.HTTPErrorOnError,
 	}
 
-	return nil
+	metricsHandler.Handle("/metrics", promhttp.HandlerFor(prometheus.DefaultGatherer, handlerOpts))
+
+    healthHandler := http.NewServeMux()
+    healthHandler.Handle("/healthz", &health.Handler{})
+
+    metricsServer := &http.Server{
+        Addr:    opt.MetricsListenAddr,
+        Handler: metricsHandler,
+    }
+
+    healthServer := &http.Server{
+        Addr:    opt.HealthProbeListenAddr,
+        Handler: healthHandler,
+    }
+
+    // make a channel for errors for each server
+    metricsServerErrChan := make(chan error)
+    healthServerErrChan := make(chan error)
+
+    // start servers in their own goroutines
+    go func() {
+        defer close(metricsServerErrChan)
+        err := metricsServer.ListenAndServe()
+        if err != nil && err != http.ErrServerClosed {
+            metricsServerErrChan <- err
+        }
+    }()
+
+    go func() {
+        defer close(healthServerErrChan)
+        err := healthServer.ListenAndServe()
+        if err != nil && err != http.ErrServerClosed {
+            healthServerErrChan <- err
+        }
+    }()
+
+    // use select to wait for either a shutdown signal or an error
+    select {
+    case <-ctx.Done():
+        // received an OS shutdown signal, shut down servers gracefully
+        ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+        defer cancel()
+
+  		errM := metricsServer.Shutdown(ctx)
+		if errM != nil {
+			return fmt.Errorf("metrics server shutdown error: %v", errM)
+		}
+   		errH := healthServer.Shutdown(ctx)
+			if errH != nil {
+			return fmt.Errorf("health server shutdown error: %v", errH)
+		}
+    case err := <-metricsServerErrChan:
+        return fmt.Errorf("metrics server error: %v", err)
+    case err := <-healthServerErrChan:
+        return fmt.Errorf("health server error: %v", err)
+    }
+
+    return nil
 }

--- a/cmd/kar-controllers/main.go
+++ b/cmd/kar-controllers/main.go
@@ -35,6 +35,7 @@ import (
 	"fmt"
 	"os"
 
+	"k8s.io/apiserver/pkg/server"
 	"k8s.io/klog/v2"
 
 	"github.com/project-codeflare/multi-cluster-app-dispatcher/cmd/kar-controllers/app"
@@ -49,8 +50,15 @@ func main() {
 	s.AddFlags(flagSet)
 	flag.Parse()
 
-	if err := app.Run(s); err != nil {
+	ctx := server.SetupSignalContext()
+
+	// Run the server
+	if err := app.Run(ctx, s); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
+
+	<-ctx.Done()
+	fmt.Println("Shutting down gracefully")
+	
 }

--- a/cmd/kar-controllers/main.go
+++ b/cmd/kar-controllers/main.go
@@ -58,7 +58,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	<-ctx.Done()
 	fmt.Println("Shutting down gracefully")
 	
 }

--- a/cmd/kar-controllers/main.go
+++ b/cmd/kar-controllers/main.go
@@ -1,19 +1,4 @@
 /*
-Copyright 2017 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-/*
 Copyright 2019, 2021 The Multi-Cluster App Dispatcher Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/kar-controllers/main.go
+++ b/cmd/kar-controllers/main.go
@@ -43,6 +43,4 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Println("Shutting down gracefully")
-	
 }

--- a/deployment/mcad-controller/templates/deployment.yaml
+++ b/deployment/mcad-controller/templates/deployment.yaml
@@ -11,8 +11,24 @@ spec:
   - name: http
     port: 80
     targetPort: 8080
+  - name: metrics
+    port: 8083
+    targetPort: 8083
   selector:
     app: custom-metrics-apiserver
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics
+  namespace: kube-system
+spec:
+  ports:
+  - name: metrics
+    port: 8083
+    targetPort: 8083
+  selector:
+    app: metrics
 ---
 #{{ if .Values.configMap.quotaRestUrl }}
 apiVersion: v1
@@ -260,6 +276,8 @@ spec:
           name: https
         - containerPort: 8080
           name: http
+        - containerPort: 8083
+          name: metrics
         volumeMounts:
         - mountPath: /tmp
           name: temp-vol

--- a/deployment/mcad-controller/templates/deployment.yaml
+++ b/deployment/mcad-controller/templates/deployment.yaml
@@ -12,8 +12,8 @@ spec:
     port: 80
     targetPort: 8080
   - name: metrics
-    port: 8083
-    targetPort: 8083
+    port: 9090
+    targetPort: 9090
   selector:
     app: custom-metrics-apiserver
 ---
@@ -25,8 +25,8 @@ metadata:
 spec:
   ports:
   - name: metrics
-    port: 8083
-    targetPort: 8083
+    port: 9090
+    targetPort: 9090
   selector:
     app: metrics
 ---
@@ -276,7 +276,7 @@ spec:
           name: https
         - containerPort: 8080
           name: http
-        - containerPort: 8083
+        - containerPort: 9090
           name: metrics
         volumeMounts:
         - mountPath: /tmp


### PR DESCRIPTION
Using port 9090 , the conventional prom port.

[this PR in odh-deployer](https://github.com/red-hat-data-services/odh-deployer/pull/365) will need to be updated also, I will get to it asap