### PR TITLE
Adding GPUs to Kind cluster

### DIFF
--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -409,7 +409,7 @@ function extend-resources {
                                 --data '[{"op": "add", "path": "/status/capacity/'${resource_name}'", "value": "'${resource_count}'"}]' \
                                 http://localhost:8001/api/v1/nodes/${node_name}/status | jq -r '.status')
 
-        if [[ ${patching_status} = "Failure" ]]; then
+        if [[ ${patching_status} == "Failure" ]]; then
             echo "Failed to patch node '${node_name}' with GPU resources"
             exit 1
         fi

--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -45,7 +45,7 @@ export IMAGE_MCAD="${IMAGE_REPOSITORY_MCAD}:${IMAGE_TAG_MCAD}"
 CLUSTER_STARTED="false"
 export KUTTL_VERSION=0.15.0
 export KUTTL_OPTIONS=${TEST_KUTTL_OPTIONS}
-export KUTTL_TEST_SUITES=("${ROOT_DIR}/test/kuttl-test-extended-resources.yaml" "${ROOT_DIR}/test/kuttl-test.yaml" "${ROOT_DIR}/test/kuttl-test-deployment-03.yaml" "${ROOT_DIR}/test/kuttl-test-deployment-02.yaml" "${ROOT_DIR}/test/kuttl-test-deployment-01.yaml")
+export KUTTL_TEST_SUITES=("${ROOT_DIR}/test/kuttl-test.yaml" "${ROOT_DIR}/test/kuttl-test-deployment-03.yaml" "${ROOT_DIR}/test/kuttl-test-deployment-02.yaml" "${ROOT_DIR}/test/kuttl-test-deployment-01.yaml")
 DUMP_LOGS="true"
 
 
@@ -408,6 +408,16 @@ function extend-resources {
     # Stop communication with cluster
     echo "Killing proxy (pid=${PROXY_PID})..."
     kill ${PROXY_PID}
+
+    # Run kuttl tests to confirm GPUs were added correctly
+    kuttl_test="${ROOT_DIR}/test/kuttl-test-extended-resources.yaml"
+    echo "kubectl kuttl test --config ${kuttl_test}"
+    kubectl kuttl test --config ${kuttl_test}
+    if [ $? -ne 0 ]
+    then
+      echo "kuttl e2e test '${kuttl_test}' failure, exiting."
+      exit 1
+    fi
 }
 
 function kuttl-tests {

--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -399,10 +399,11 @@ function kuttl-tests {
 }
 
 trap cleanup EXIT
-exit
 update_test_host
 check-prerequisites 
 kind-up-cluster
+kubectl get all nodes
+exit
 setup-mcad-env
 # MCAD with quotamanagement options is started by kuttl-tests
 kuttl-tests

--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -437,7 +437,7 @@ update_test_host
 check-prerequisites 
 kind-up-cluster
 extend-resources
-kubectl describe all nodes
+kubectl describe nodes
 exit
 setup-mcad-env
 # MCAD with quotamanagement options is started by kuttl-tests

--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -399,6 +399,7 @@ function kuttl-tests {
 }
 
 trap cleanup EXIT
+exit
 update_test_host
 check-prerequisites 
 kind-up-cluster

--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -45,8 +45,7 @@ export IMAGE_MCAD="${IMAGE_REPOSITORY_MCAD}:${IMAGE_TAG_MCAD}"
 CLUSTER_STARTED="false"
 export KUTTL_VERSION=0.15.0
 export KUTTL_OPTIONS=${TEST_KUTTL_OPTIONS}
-#export KUTTL_TEST_SUITES=("${ROOT_DIR}/test/kuttl-test.yaml" "${ROOT_DIR}/test/kuttl-test-deployment-03.yaml" "${ROOT_DIR}/test/kuttl-test-deployment-02.yaml" "${ROOT_DIR}/test/kuttl-test-deployment-01.yaml")
-export KUTTL_TEST_SUITES=("${ROOT_DIR}/test/kuttl-test-extended-resources.yaml")
+export KUTTL_TEST_SUITES=("${ROOT_DIR}/test/kuttl-test-extended-resources.yaml" "${ROOT_DIR}/test/kuttl-test.yaml" "${ROOT_DIR}/test/kuttl-test-deployment-03.yaml" "${ROOT_DIR}/test/kuttl-test-deployment-02.yaml" "${ROOT_DIR}/test/kuttl-test-deployment-01.yaml")
 DUMP_LOGS="true"
 
 

--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -45,7 +45,8 @@ export IMAGE_MCAD="${IMAGE_REPOSITORY_MCAD}:${IMAGE_TAG_MCAD}"
 CLUSTER_STARTED="false"
 export KUTTL_VERSION=0.15.0
 export KUTTL_OPTIONS=${TEST_KUTTL_OPTIONS}
-export KUTTL_TEST_SUITES=("${ROOT_DIR}/test/kuttl-test.yaml" "${ROOT_DIR}/test/kuttl-test-deployment-03.yaml" "${ROOT_DIR}/test/kuttl-test-deployment-02.yaml" "${ROOT_DIR}/test/kuttl-test-deployment-01.yaml")
+#export KUTTL_TEST_SUITES=("${ROOT_DIR}/test/kuttl-test.yaml" "${ROOT_DIR}/test/kuttl-test-deployment-03.yaml" "${ROOT_DIR}/test/kuttl-test-deployment-02.yaml" "${ROOT_DIR}/test/kuttl-test-deployment-01.yaml")
+export KUTTL_TEST_SUITES=("${ROOT_DIR}/test/kuttl-test-extended-resources.yaml")
 DUMP_LOGS="true"
 
 
@@ -437,8 +438,6 @@ update_test_host
 check-prerequisites 
 kind-up-cluster
 extend-resources
-kubectl describe nodes
-exit
 setup-mcad-env
 # MCAD with quotamanagement options is started by kuttl-tests
 kuttl-tests

--- a/test/e2e-kuttl-extended-resources/steps/00-assert.yaml
+++ b/test/e2e-kuttl-extended-resources/steps/00-assert.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Node
 metadata:
-    name: minikube # CHANGE NAME
+    name: test-worker
 status:
     allocatable:
         nvidia.com/gpu: "8"

--- a/test/e2e-kuttl-extended-resources/steps/00-assert.yaml
+++ b/test/e2e-kuttl-extended-resources/steps/00-assert.yaml
@@ -1,0 +1,10 @@
+---
+# Verify that GPUs are a resource for the node
+apiVersion: v1
+kind: Node
+metadata:
+    name: minikube # CHANGE NAME
+status:
+    allocatable:
+        nvidia.com/gpu: "8"
+

--- a/test/e2e-kuttl-extended-resources/steps/01-assert.yaml
+++ b/test/e2e-kuttl-extended-resources/steps/01-assert.yaml
@@ -1,0 +1,8 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+    name: gpu-job
+    namespace: test
+status:
+    conditions:
+        - type: Complete

--- a/test/e2e-kuttl-extended-resources/steps/01-assert.yaml
+++ b/test/e2e-kuttl-extended-resources/steps/01-assert.yaml
@@ -1,8 +1,5 @@
-apiVersion: batch/v1
-kind: Job
+# Verify that the namespace was created
+apiVersion: v1
+kind: Namespace
 metadata:
-    name: gpu-job
-    namespace: test
-status:
-    conditions:
-        - type: Complete
+  name: extended-resources

--- a/test/e2e-kuttl-extended-resources/steps/01-install.yaml
+++ b/test/e2e-kuttl-extended-resources/steps/01-install.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+    name: gpu-job
+    namespace: test
+spec:
+    template:
+        spec:
+            restartPolicy: Never
+            containers:
+                - name: gpu-job
+                  image: ubuntu:latest
+                  command: [ "/bin/bash", "-c", "--" ]
+                  args: [ "sleep 10;" ]
+                  resources:
+                      requests:
+                          nvidia.com/gpu: 8
+                      limits:
+                          nvidia.com/gpu: 8

--- a/test/e2e-kuttl-extended-resources/steps/01-install.yaml
+++ b/test/e2e-kuttl-extended-resources/steps/01-install.yaml
@@ -1,19 +1,4 @@
-apiVersion: batch/v1
-kind: Job
+apiVersion: v1
+kind: Namespace
 metadata:
-    name: gpu-job
-    namespace: test
-spec:
-    template:
-        spec:
-            restartPolicy: Never
-            containers:
-                - name: gpu-job
-                  image: ubuntu:latest
-                  command: [ "/bin/bash", "-c", "--" ]
-                  args: [ "sleep 10;" ]
-                  resources:
-                      requests:
-                          nvidia.com/gpu: 8
-                      limits:
-                          nvidia.com/gpu: 8
+  name: extended-resources

--- a/test/e2e-kuttl-extended-resources/steps/02-assert.yaml
+++ b/test/e2e-kuttl-extended-resources/steps/02-assert.yaml
@@ -1,0 +1,8 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+    name: gpu-job
+    namespace: extended-resources
+status:
+    conditions:
+        - type: Complete

--- a/test/e2e-kuttl-extended-resources/steps/02-install.yaml
+++ b/test/e2e-kuttl-extended-resources/steps/02-install.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+    name: gpu-job
+    namespace: extended-resources
+spec:
+    template:
+        spec:
+            restartPolicy: Never
+            containers:
+                - name: gpu-job
+                  image: ubuntu:latest
+                  command: [ "/bin/bash", "-c", "--" ]
+                  args: [ "sleep 10;" ]
+                  resources:
+                      requests:
+                          nvidia.com/gpu: 8
+                      limits:
+                          nvidia.com/gpu: 8

--- a/test/kuttl-test-extended-resources.yaml
+++ b/test/kuttl-test-extended-resources.yaml
@@ -1,0 +1,8 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+testDirs:
+  - test/e2e-kuttl-extended-resources/
+timeout: 60
+artifactsDir: _output/logs
+commands:
+ 

--- a/test/kuttl-test-extended-resources.yaml
+++ b/test/kuttl-test-extended-resources.yaml
@@ -5,4 +5,3 @@ testDirs:
 timeout: 60
 artifactsDir: _output/logs
 commands:
- 


### PR DESCRIPTION
This update patches the nodes created by `kind` by extending the resources to include GPUs. These GPUs are just there as a count and do now represent real GPUs. This version of the build system will allow tests to include GPUs even when the cluster doesn't have physical GPUs.