### PR TITLE
Reduce mcad logs

### DIFF
--- a/deployment/mcad-controller/values.yaml
+++ b/deployment/mcad-controller/values.yaml
@@ -4,7 +4,7 @@
 deploymentName: mcad-controller
 namespace: kube-system
 replicaCount: 1
-loglevel: 4
+loglevel: 3
 
 image:
   repository: mcad-controller


### PR DESCRIPTION
Resolves #459 

Log level reduced to 3, in order to immediately reduce amount of logs printed. 
Follow on tickets will also be created to improve logs.