### PR TITLE
Add support for try and undo allocate

### DIFF
--- a/pkg/quotaplugins/quota-forest/quota-manager/README.md
+++ b/pkg/quotaplugins/quota-forest/quota-manager/README.md
@@ -188,6 +188,11 @@ A summary of the API interface to the Quota Manager follows.
 - Forest Updates
   - refresh (effect) updates from caches
     - `UpdateForest(forestName)`
+- Undo consumer allocation: Two calls are provided to try to allocate a consumer, and if unaccepted, to undo the effect of the allocation trial. If the trial is accepted, no further action is needed. Otherwise, the undo has to be called right after the try allocation, without making any calls to change the trees or allocate/deallocate consumers. These operations are intended only during Normal mode.
+  - `TryAllocate(treeName, consumerID)`
+  - `UndoAllocate(treeName, consumerID)`
+  - `TryAllocateForest(forestName, consumerID)`
+  - `UndoAllocateForest(forestName, consumerID)`
 
 Examples of using the Quota Manager in the case of a [single tree](demos/manager/tree/demo.go) and a [forest](demos/manager/forest/demo.go) are provided.
 

--- a/pkg/quotaplugins/quota-forest/quota-manager/README.md
+++ b/pkg/quotaplugins/quota-forest/quota-manager/README.md
@@ -189,6 +189,7 @@ A summary of the API interface to the Quota Manager follows.
   - refresh (effect) updates from caches
     - `UpdateForest(forestName)`
 - Undo consumer allocation: Two calls are provided to try to allocate a consumer, and if unaccepted, to undo the effect of the allocation trial. If the trial is accepted, no further action is needed. Otherwise, the undo has to be called right after the try allocation, without making any calls to change the trees or allocate/deallocate consumers. These operations are intended only during Normal mode.
+(Note: This design pattern puts the burden on the caller of the quota manager to make sure that TryAllocate() and UndoAllocate() are run in an atomic fashion. So, a lock is needed for that purpose. An example is provided in the TestQuotaManagerParallelTryUndoAllocation() in [quotamanagerundo_test.go](quota/quotamanagerundo_test.go))
   - `TryAllocate(treeName, consumerID)`
   - `UndoAllocate(treeName, consumerID)`
   - `TryAllocateForest(forestName, consumerID)`

--- a/pkg/quotaplugins/quota-forest/quota-manager/demos/undo/forest/demo.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/demos/undo/forest/demo.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2023 The Multi-Cluster App Dispatcher Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/project-codeflare/multi-cluster-app-dispatcher/pkg/quotaplugins/quota-forest/quota-manager/quota"
+	"k8s.io/klog/v2"
+)
+
+func main() {
+	klog.InitFlags(nil)
+	flag.Set("v", "4")
+	flag.Set("skip_headers", "true")
+	klog.SetOutput(os.Stdout)
+	flag.Parse()
+	defer klog.Flush()
+
+	fmt.Println("Demo of allocation and de-allocation of consumers on a forest using the quota manager.")
+	fmt.Println()
+	prefix := "../../../samples/forest/"
+	indent := "===> "
+	forestName := "Context-Service"
+	treeNames := []string{"ContextTree", "ServiceTree"}
+
+	// create a quota manager
+	fmt.Println(indent + "Creating quota manager ... " + "\n")
+	quotaManager := quota.NewManager()
+	quotaManager.SetMode(quota.Normal)
+	fmt.Println(quotaManager.GetModeString())
+	fmt.Println()
+
+	//	create multiple trees
+	fmt.Println(indent + "Creating multiple trees ..." + "\n")
+	for _, treeName := range treeNames {
+		fName := prefix + treeName + ".json"
+		fmt.Printf("Tree file name: %s\n", fName)
+		jsonTree, err := os.ReadFile(fName)
+		if err != nil {
+			fmt.Printf("error reading quota tree file: %s", fName)
+			return
+		}
+		_, err = quotaManager.AddTreeFromString(string(jsonTree))
+		if err != nil {
+			fmt.Printf("error adding tree %s: %v", treeName, err)
+			return
+		}
+	}
+
+	// create forest
+	fmt.Println(indent + "Creating forest " + forestName + " ..." + "\n")
+	quotaManager.AddForest(forestName)
+	for _, treeName := range treeNames {
+		quotaManager.AddTreeToForest(forestName, treeName)
+	}
+	fmt.Println(quotaManager)
+
+	//	create consumer jobs
+	fmt.Println(indent + "Allocating consumers on forest ..." + "\n")
+	jobs := []string{"job1", "job2", "job3", "job4", "job5"}
+	for _, job := range jobs {
+
+		// create consumer info
+		fName := prefix + job + ".json"
+		fmt.Printf("Consumer file name: %s\n", fName)
+		consumerInfo, err := quota.NewConsumerInfoFromFile(fName)
+		if err != nil {
+			fmt.Printf("error reading consumer file: %s \n", fName)
+			continue
+		}
+		consumerID := consumerInfo.GetID()
+
+		// add consumer info to quota manager
+		quotaManager.AddConsumer(consumerInfo)
+
+		// allocate forest consumer instance of the consumer info
+		if job == "job4" {
+			_, err = quotaManager.TryAllocateForest(forestName, consumerID)
+			if err != nil {
+				fmt.Printf("error allocating consumer: %v \n", err)
+			}
+			err = quotaManager.UndoAllocateForest(forestName, "job-4")
+			if err != nil {
+				fmt.Printf("error undoing allocation consumer: %v \n", err)
+			}
+			_, err = quotaManager.AllocateForest(forestName, consumerID)
+		} else {
+			_, err = quotaManager.AllocateForest(forestName, consumerID)
+		}
+
+		if err != nil {
+			fmt.Printf("error allocating consumer: %v \n", err)
+			quotaManager.RemoveConsumer((consumerID))
+			continue
+		}
+	}
+
+	// de-allocate consumers from forest
+	fmt.Println(indent + "De-allocating consumers from forest ..." + "\n")
+	for _, id := range quotaManager.GetAllConsumerIDs() {
+		quotaManager.DeAllocateForest(forestName, id)
+		quotaManager.RemoveConsumer(id)
+	}
+	fmt.Println()
+	fmt.Println(quotaManager)
+}

--- a/pkg/quotaplugins/quota-forest/quota-manager/demos/undo/tree/demo.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/demos/undo/tree/demo.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2023 The Multi-Cluster App Dispatcher Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/project-codeflare/multi-cluster-app-dispatcher/pkg/quotaplugins/quota-forest/quota-manager/quota"
+	"github.com/project-codeflare/multi-cluster-app-dispatcher/pkg/quotaplugins/quota-forest/quota-manager/quota/core"
+	klog "k8s.io/klog/v2"
+)
+
+func main() {
+	klog.InitFlags(nil)
+	flag.Set("v", "4")
+	flag.Set("skip_headers", "true")
+	klog.SetOutput(os.Stdout)
+	flag.Parse()
+	defer klog.Flush()
+
+	prefix := "../../../samples/tree/"
+	treeFileName := prefix + "tree.json"
+	caFileName := prefix + "ca.json"
+	cbFileName := prefix + "cb.json"
+	ccFileName := prefix + "cc.json"
+	cdFileName := prefix + "cd.json"
+	ceFileName := prefix + "ce.json"
+
+	// create a quota manager
+	fmt.Println("==> Creating Quota Manager")
+	fmt.Println("**************************")
+	quotaManager := quota.NewManager()
+	treeJsonString, err := os.ReadFile(treeFileName)
+	if err != nil {
+		fmt.Printf("error reading quota tree file: %s", treeFileName)
+		return
+	}
+	quotaManager.SetMode(quota.Normal)
+
+	// add a quota tree from file
+	treeName, err := quotaManager.AddTreeFromString(string(treeJsonString))
+	if err != nil {
+		fmt.Printf("error adding tree %s: %v", treeName, err)
+		return
+	}
+
+	// allocate consumers
+	allocate(quotaManager, treeName, caFileName, false)
+	allocate(quotaManager, treeName, cbFileName, false)
+	allocate(quotaManager, treeName, ccFileName, false)
+
+	// try and undo allocation
+	allocate(quotaManager, treeName, cdFileName, true)
+	undoAllocate(quotaManager, treeName, cdFileName)
+
+	// allocate consumers
+	allocate(quotaManager, treeName, ceFileName, false)
+}
+
+// allocate consumer from file
+func allocate(quotaManager *quota.Manager, treeName string, consumerFileName string, try bool) {
+	consumerInfo := getConsumerInfo(consumerFileName)
+	if consumerInfo == nil {
+		fmt.Printf("error reading consumer file: %s", consumerFileName)
+		return
+	}
+	consumerID := consumerInfo.GetID()
+	fmt.Println("==> Allocating consumer " + consumerID)
+	fmt.Println("**************************")
+	quotaManager.AddConsumer(consumerInfo)
+
+	var allocResponse *core.AllocationResponse
+	var err error
+	if try {
+		allocResponse, err = quotaManager.TryAllocate(treeName, consumerID)
+	} else {
+		allocResponse, err = quotaManager.Allocate(treeName, consumerID)
+	}
+	if err != nil {
+		fmt.Printf("error allocating consumer: %v", err)
+		return
+	}
+	fmt.Println(allocResponse)
+	fmt.Println(quotaManager)
+}
+
+// undo most recent consumer allocation
+func undoAllocate(quotaManager *quota.Manager, treeName string, consumerFileName string) {
+	consumerInfo := getConsumerInfo(consumerFileName)
+	if consumerInfo == nil {
+		fmt.Printf("error reading consumer file: %s", consumerFileName)
+		return
+	}
+	consumerID := consumerInfo.GetID()
+	fmt.Println("==> Undo allocating consumer " + consumerID)
+	fmt.Println("**************************")
+	quotaManager.UndoAllocate(treeName, consumerID)
+	fmt.Println(quotaManager)
+}
+
+// get consumer info from yaml file
+func getConsumerInfo(consumerFileName string) *quota.ConsumerInfo {
+	consumerInfo, err := quota.NewConsumerInfoFromFile(consumerFileName)
+	if err != nil {
+		fmt.Printf("error reading consumer file: %s", consumerFileName)
+		return nil
+	}
+	return consumerInfo
+}

--- a/pkg/quotaplugins/quota-forest/quota-manager/quota/consumerinfo.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/quota/consumerinfo.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Multi-Cluster App Dispatcher Authors.
+Copyright 2022, 2023 The Multi-Cluster App Dispatcher Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package quota
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/project-codeflare/multi-cluster-app-dispatcher/pkg/quotaplugins/quota-forest/quota-manager/quota/core"
 	"github.com/project-codeflare/multi-cluster-app-dispatcher/pkg/quotaplugins/quota-forest/quota-manager/quota/utils"
@@ -49,7 +49,7 @@ func NewConsumerInfo(consumerStruct utils.JConsumer) (*ConsumerInfo, error) {
 
 // NewConsumerInfoFromFile : create a new ConsumerInfo from Json file
 func NewConsumerInfoFromFile(consumerFileName string) (*ConsumerInfo, error) {
-	byteValue, err := ioutil.ReadFile(consumerFileName)
+	byteValue, err := os.ReadFile(consumerFileName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/quotaplugins/quota-forest/quota-manager/quota/core/consumer.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/quota/core/consumer.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2022 The Multi-Cluster App Dispatcher Authors.
+Copyright 2022, 2023 The Multi-Cluster App Dispatcher Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -118,6 +118,13 @@ func (c *Consumer) SetNode(aNode *QuotaNode) {
 func (c *Consumer) IsAllocated() bool {
 	return c.aNode != nil
 }
+
+// ByID implements sort.Interface based on the ID field.
+type ByID []*Consumer
+
+func (c ByID) Len() int           { return len(c) }
+func (c ByID) Less(i, j int) bool { return c[i].id < c[j].id }
+func (c ByID) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
 
 // String : a print out of the consumer
 func (c *Consumer) String() string {

--- a/pkg/quotaplugins/quota-forest/quota-manager/quota/core/forestconsumer.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/quota/core/forestconsumer.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2022 The Multi-Cluster App Dispatcher Authors.
+Copyright 2022, 2023 The Multi-Cluster App Dispatcher Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	utils "github.com/project-codeflare/multi-cluster-app-dispatcher/pkg/quotaplugins/quota-forest/quota-manager/quota/utils"
 )
@@ -42,7 +42,7 @@ func NewForestConsumer(id string, consumers map[string]*Consumer) *ForestConsume
 
 // NewForestConsumerFromFile : create a forest consumer from JSON file
 func NewForestConsumerFromFile(consumerFileName string, resourceNames map[string][]string) (*ForestConsumer, error) {
-	byteValue, err := ioutil.ReadFile(consumerFileName)
+	byteValue, err := os.ReadFile(consumerFileName)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (fc *ForestConsumer) GetTreeConsumer(treeName string) *Consumer {
 	return fc.consumers[treeName]
 }
 
-//IsAllocated : is consumer allocated on all trees in the forest
+// IsAllocated : is consumer allocated on all trees in the forest
 func (fc *ForestConsumer) IsAllocated() bool {
 	for _, consumer := range fc.consumers {
 		if !consumer.IsAllocated() {

--- a/pkg/quotaplugins/quota-forest/quota-manager/quota/core/forestcontroller.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/quota/core/forestcontroller.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -144,7 +144,7 @@ func (fc *ForestController) Allocate(forestConsumer *ForestConsumer) *Allocation
 			} else if len(groupID) == 0 {
 				fmt.Fprintf(&msg, "No quota designations provided for '%s'", treeName)
 			} else {
-				fmt.Fprintf(&msg, "Explected %d resources for quota designations '%s', received %d",
+				fmt.Fprintf(&msg, "Expected %d resources for quota designations '%s', received %d",
 					controller.GetQuotaSize(), treeName, allocRequested.GetSize())
 			}
 			return fc.failureRecover(consumerID, processedTrees, deletedConsumers, msg.String())
@@ -187,6 +187,7 @@ func (fc *ForestController) Allocate(forestConsumer *ForestConsumer) *Allocation
 			/*
 			 * allocation failed - undo deletions of prior preempted consumers and recover
 			 */
+			// TODO: make use of forest snapshot to recover
 			for _, c := range treeDeletedConsumers {
 				controller.Allocate(c)
 			}
@@ -243,6 +244,46 @@ func (fc *ForestController) failureRecover(consumerID string, processedTrees []s
 	klog.V(4).Infoln(failedResponse)
 
 	return failedResponse
+}
+
+// TryAllocate : try allocating a consumer by taking a snapshot before attempting allocation
+func (fc *ForestController) TryAllocate(forestConsumer *ForestConsumer) *AllocationResponse {
+	consumerID := forestConsumer.GetID()
+	consumers := forestConsumer.GetConsumers()
+	allocResponse := NewAllocationResponse(consumerID)
+
+	// take a snapshot of the forest
+	for treeName, consumer := range consumers {
+		var msg bytes.Buffer
+		controller := fc.controllers[treeName]
+		controller.treeSnapshot = NewTreeSnapshot(controller.tree, consumer)
+		// TODO: limit the number of potentially affected consumers by the allocation
+		if !controller.treeSnapshot.Take(controller, controller.consumers) {
+			fmt.Fprintf(&msg, "Failed to take a state snapshot of tree '%s'", controller.GetTreeName())
+			treeAllocResponse := NewAllocationResponse(consumer.GetID())
+			preemptedIds := make([]string, 0)
+			treeAllocResponse.Append(false, msg.String(), &preemptedIds)
+			allocResponse.Merge(treeAllocResponse)
+			return allocResponse
+		}
+	}
+
+	ar := fc.Allocate(forestConsumer)
+	allocResponse.Merge(ar)
+	return allocResponse
+}
+
+// UndoAllocate : undo the most recent allocation trial
+func (fc *ForestController) UndoAllocate(forestConsumer *ForestConsumer) bool {
+	klog.V(4).Infof("Multi-quota undo allocation of consumer: %s\n", forestConsumer.GetID())
+	consumers := forestConsumer.GetConsumers()
+	success := true
+	for treeName, consumer := range consumers {
+		controller := fc.controllers[treeName]
+		treeSuccess := controller.UndoAllocate(consumer)
+		success = success && treeSuccess
+	}
+	return success
 }
 
 // ForceAllocate : force allocate a consumer on a given set of nodes on trees;

--- a/pkg/quotaplugins/quota-forest/quota-manager/quota/core/helpers.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/quota/core/helpers.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2023 The Multi-Cluster App Dispatcher Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"reflect"
+	"sort"
+)
+
+// EqualStateQuotaNodes : check if two quota nodes have similar allocation data
+func EqualStateQuotaNodes(qn1 *QuotaNode, qn2 *QuotaNode) bool {
+	consumers1 := make([]*Consumer, len(qn1.GetConsumers()))
+	copy(consumers1, qn1.GetConsumers())
+	sort.Sort(ByID(consumers1))
+
+	consumers2 := make([]*Consumer, len(qn2.GetConsumers()))
+	copy(consumers2, qn2.GetConsumers())
+	sort.Sort(ByID(consumers2))
+
+	return reflect.DeepEqual(qn1.GetQuota(), qn2.GetQuota()) &&
+		reflect.DeepEqual(qn1.GetAllocated(), qn2.GetAllocated()) &&
+		reflect.DeepEqual(consumers1, consumers2)
+}
+
+// EqualStateQuotaTrees : check if two quota trees have similar allocation data
+func EqualStateQuotaTrees(qt1 *QuotaTree, qt2 *QuotaTree) bool {
+	nodeMap1 := qt1.GetNodes()
+	nodeMap2 := qt2.GetNodes()
+	if len(nodeMap1) != len(nodeMap2) {
+		return false
+	}
+	for k, qn1 := range nodeMap1 {
+		if qn2, exists := nodeMap2[k]; exists {
+			if !EqualStateQuotaNodes(qn1, qn2) {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	return true
+}
+
+// EqualStateControllers : check if two controllers have similar allocation state
+func EqualStateControllers(c1 *Controller, c2 *Controller) bool {
+	pc1 := c1.GetPreemptedConsumers()
+	sort.Strings(pc1)
+	pc2 := c2.GetPreemptedConsumers()
+	sort.Strings(pc2)
+
+	pca1 := c1.GetPreemptedConsumersArray()
+	sort.Sort(ByID(pca1))
+	pca2 := c2.GetPreemptedConsumersArray()
+	sort.Sort(ByID(pca2))
+
+	return EqualStateQuotaTrees(c1.GetTree(), c2.GetTree()) &&
+		reflect.DeepEqual(c1.GetConsumers(), c1.GetConsumers()) &&
+		reflect.DeepEqual(pc1, pc2) &&
+		reflect.DeepEqual(pca1, pca2)
+}
+
+// EqualStateControllers : check if two forest controllers have similar allocation state
+func EqualStateForestControllers(fc1 *ForestController, fc2 *ForestController) bool {
+	c1Map := fc1.GetControllers()
+	c2Map := fc2.GetControllers()
+	if len(c1Map) != len(c2Map) {
+		return false
+	}
+	for k, c1 := range c1Map {
+		if c2, exists := c2Map[k]; exists {
+			if !EqualStateControllers(c1, c2) {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/quotaplugins/quota-forest/quota-manager/quota/core/quotanode.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/quota/core/quotanode.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Multi-Cluster App Dispatcher Authors.
+Copyright 2022, 2023 The Multi-Cluster App Dispatcher Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/quotaplugins/quota-forest/quota-manager/quota/core/quotanode.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/quota/core/quotanode.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -218,9 +218,19 @@ func (qn *QuotaNode) GetAllocated() *Allocation {
 	return qn.allocated
 }
 
+// SetAllocated :
+func (qn *QuotaNode) SetAllocated(alloc *Allocation) {
+	qn.allocated = alloc
+}
+
 // GetConsumers :
 func (qn *QuotaNode) GetConsumers() []*Consumer {
 	return qn.consumers
+}
+
+// SetConsumers :
+func (qn *QuotaNode) SetConsumers(consumers []*Consumer) {
+	qn.consumers = consumers
 }
 
 // String : print node with a specified level of indentation

--- a/pkg/quotaplugins/quota-forest/quota-manager/quota/core/quotatree.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/quota/core/quotatree.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Multi-Cluster App Dispatcher Authors.
+Copyright 2022, 2023 The Multi-Cluster App Dispatcher Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/quotaplugins/quota-forest/quota-manager/quota/core/quotatree.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/quota/core/quotatree.go
@@ -209,6 +209,15 @@ func (qt *QuotaTree) GetQuotaSize() int {
 	return len(qt.resourceNames)
 }
 
+// GetNodes : get a map of all quota nodes in the tree
+func (qt *QuotaTree) GetNodes() map[string]*QuotaNode {
+	nodeMap := make(map[string]*QuotaNode)
+	for _, n := range qt.Tree.GetNodeListBFS() {
+		nodeMap[n.GetID()] = (*QuotaNode)(unsafe.Pointer(n))
+	}
+	return nodeMap
+}
+
 // StringSimply :
 func (qt *QuotaTree) StringSimply() string {
 	var b bytes.Buffer

--- a/pkg/quotaplugins/quota-forest/quota-manager/quota/core/treecache.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/quota/core/treecache.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2022 The Multi-Cluster App Dispatcher Authors.
+Copyright 2022, 2023 The Multi-Cluster App Dispatcher Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -243,7 +243,7 @@ func (tc *TreeCache) FromFile(treeFileName string) error {
 	/*
 	 * parse JSON file
 	 */
-	byteValue, err := ioutil.ReadFile(treeFileName)
+	byteValue, err := os.ReadFile(treeFileName)
 	if err != nil {
 		return fmt.Errorf("error reading file: %s", err.Error())
 	}

--- a/pkg/quotaplugins/quota-forest/quota-manager/quota/core/treecontroller.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/quota/core/treecontroller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Multi-Cluster App Dispatcher Authors.
+Copyright 2022, 2023 The Multi-Cluster App Dispatcher Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/quotaplugins/quota-forest/quota-manager/quota/core/treecontroller.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/quota/core/treecontroller.go
@@ -138,6 +138,11 @@ func (controller *Controller) DeAllocate(consumerID string) bool {
 	return false
 }
 
+// GetConsumers : get a map of consumers in controller
+func (controller *Controller) GetConsumers() map[string]*Consumer {
+	return controller.consumers
+}
+
 // GetPreemptedConsumers : get a list of the preempted consumer IDs
 func (controller *Controller) GetPreemptedConsumers() []string {
 	return controller.preemptedConsumers

--- a/pkg/quotaplugins/quota-forest/quota-manager/quota/core/treecontroller.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/quota/core/treecontroller.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -35,6 +35,9 @@ type Controller struct {
 	preemptedConsumers []string
 	// list of preempted consumer objects due to previous allocation request
 	preemptedConsumersArray []*Consumer
+
+	// snapshot of tree state to undo most recent allocation
+	treeSnapshot *TreeSnapshot
 }
 
 // NewController : create a quota controller
@@ -44,6 +47,7 @@ func NewController(tree *QuotaTree) *Controller {
 		consumers:               make(map[string]*Consumer),
 		preemptedConsumers:      make([]string, 0),
 		preemptedConsumersArray: make([]*Consumer, 0),
+		treeSnapshot:            nil,
 	}
 }
 
@@ -66,7 +70,6 @@ func (controller *Controller) Allocate(consumer *Consumer) *AllocationResponse {
 		}
 	} else {
 		fmt.Fprintf(&allocationMessage, "Failed to allocate quota on quota designation '%s'", controller.GetTreeName())
-
 	}
 	controller.PrintState(consumer, allocated)
 	preemptedIds := make([]string, len(controller.preemptedConsumers))
@@ -74,6 +77,32 @@ func (controller *Controller) Allocate(consumer *Consumer) *AllocationResponse {
 	allocResponse := NewAllocationResponse(consumer.GetID())
 	allocResponse.Append(allocated, allocationMessage.String(), &preemptedIds)
 	return allocResponse
+}
+
+// TryAllocate : try allocating a consumer by taking a snapshot before attempting allocation
+func (controller *Controller) TryAllocate(consumer *Consumer) *AllocationResponse {
+	controller.treeSnapshot = NewTreeSnapshot(controller.tree, consumer)
+	if !controller.treeSnapshot.Take(controller, nil) {
+		var allocationMessage bytes.Buffer
+		fmt.Fprintf(&allocationMessage, "Failed to take a state snapshot of tree '%s'", controller.GetTreeName())
+		allocResponse := NewAllocationResponse(consumer.GetID())
+		preemptedIds := make([]string, 0)
+		allocResponse.Append(false, allocationMessage.String(), &preemptedIds)
+		return allocResponse
+	}
+	return controller.Allocate(consumer)
+}
+
+// UndoAllocate : undo the most recent allocation trial
+func (controller *Controller) UndoAllocate(consumer *Consumer) bool {
+	success := true
+	defer controller.PrintState(consumer, success)
+	if ts := controller.treeSnapshot; ts != nil && ts.targetConsumer.GetID() == consumer.GetID() {
+		ts.Reinstate(controller)
+	} else {
+		success = false
+	}
+	return success
 }
 
 // ForceAllocate : force allocate a consumer on a given node

--- a/pkg/quotaplugins/quota-forest/quota-manager/quota/core/treecontroller_test.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/quota/core/treecontroller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package core
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 	"unsafe"
@@ -166,38 +165,4 @@ func createTestContoller(t *testing.T, treeName string) *Controller {
 	assert.Equal(t, 0, len(strings.TrimSpace(response2.GetMessage())), "A empty response 2 is expected")
 
 	return controller
-}
-
-// EqualStateQuotaNodes : check if two quota nodes have similar allocation data
-func EqualStateQuotaNodes(qn1 *QuotaNode, qn2 *QuotaNode) bool {
-	return reflect.DeepEqual(qn1.GetQuota(), qn2.GetQuota()) &&
-		reflect.DeepEqual(qn1.GetAllocated(), qn2.GetAllocated()) &&
-		reflect.DeepEqual(qn1.GetConsumers(), qn2.GetConsumers())
-}
-
-// EqualStateQuotaTrees : check if two quota trees have similar allocation data
-func EqualStateQuotaTrees(qt1 *QuotaTree, qt2 *QuotaTree) bool {
-	nodeMap1 := qt1.GetNodes()
-	nodeMap2 := qt2.GetNodes()
-	if len(nodeMap1) != len(nodeMap2) {
-		return false
-	}
-	for k, qn1 := range nodeMap1 {
-		if qn2, exists := nodeMap2[k]; exists {
-			if !EqualStateQuotaNodes(qn1, qn2) {
-				return false
-			}
-		} else {
-			return false
-		}
-	}
-	return true
-}
-
-// EqualStateControllers : check if two controllers have similar allocation state
-func EqualStateControllers(c1 *Controller, c2 *Controller) bool {
-	return EqualStateQuotaTrees(c1.tree, c2.tree) &&
-		reflect.DeepEqual(c1.consumers, c1.consumers) &&
-		reflect.DeepEqual(c1.preemptedConsumers, c2.preemptedConsumers) &&
-		reflect.DeepEqual(c1.preemptedConsumersArray, c2.preemptedConsumersArray)
 }

--- a/pkg/quotaplugins/quota-forest/quota-manager/quota/core/treecontroller_test.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/quota/core/treecontroller_test.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2023 The Multi-Cluster App Dispatcher Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"unsafe"
+
+	tree "github.com/project-codeflare/multi-cluster-app-dispatcher/pkg/quotaplugins/quota-forest/quota-manager/tree"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestControllerTryUndo : test try allocate (take snapshot) and undo allocate (reinstate)
+func TestControllerTryUndo(t *testing.T) {
+	treeName := "treeA"
+
+	// define tests
+	var tests = []struct {
+		name          string
+		consumer      *Consumer
+		wantAllocated bool
+		wantErr       bool
+	}{
+		{
+			name: "invalid consumer wrong group",
+			consumer: &Consumer{
+				id:      "C",
+				treeID:  treeName,
+				groupID: "X",
+				request: &Allocation{x: []int{1}},
+			},
+			wantAllocated: false,
+			wantErr:       true,
+		},
+		{
+			name: "insufficient quota",
+			consumer: &Consumer{
+				id:      "C",
+				treeID:  treeName,
+				groupID: "C",
+				request: &Allocation{x: []int{5}},
+			},
+			wantAllocated: false,
+			wantErr:       true,
+		},
+		{
+			name: "consumer no preemption",
+			consumer: &Consumer{
+				id:      "C",
+				treeID:  treeName,
+				groupID: "C",
+				request: &Allocation{x: []int{1}},
+			},
+			wantAllocated: true,
+			wantErr:       false,
+		},
+		{
+			name: "consumer preemption",
+			consumer: &Consumer{
+				id:      "C",
+				treeID:  treeName,
+				groupID: "B",
+				request: &Allocation{x: []int{1}},
+			},
+			wantAllocated: true,
+			wantErr:       false,
+		},
+		{
+			name: "high priority consumer no preemption",
+			consumer: &Consumer{
+				id:       "C",
+				treeID:   treeName,
+				groupID:  "C",
+				request:  &Allocation{x: []int{1}},
+				priority: 1,
+			},
+			wantAllocated: true,
+			wantErr:       false,
+		},
+		{
+			name: "high priority consumer preemption",
+			consumer: &Consumer{
+				id:       "C",
+				treeID:   treeName,
+				groupID:  "B",
+				request:  &Allocation{x: []int{2}},
+				priority: 1,
+			},
+			wantAllocated: true,
+			wantErr:       false,
+		},
+	}
+
+	// Before keeps the state of the quota tree before applying test cases
+	ctlrBefore := createTestContoller(t, treeName)
+
+	// perform tests
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// After keeps the state of the quota tree after applying a test case
+			ctlrAfter := createTestContoller(t, tt.consumer.treeID)
+
+			response := ctlrAfter.TryAllocate(tt.consumer)
+			if err := response == nil || len(strings.TrimSpace(response.GetMessage())) > 0; err != tt.wantErr {
+				t.Errorf("TryAllocate() response error, want %v", tt.wantErr)
+			}
+			if treeChanged := !EqualStateControllers(ctlrBefore, ctlrAfter); treeChanged != tt.wantAllocated {
+				t.Errorf("TryAllocate() tree changed = %v, want %v", treeChanged, tt.wantAllocated)
+			}
+			if undone := ctlrAfter.UndoAllocate(tt.consumer); !undone {
+				t.Errorf("TryAllocate() undo failed, want %v", tt.wantErr)
+			}
+			if !EqualStateControllers(ctlrAfter, ctlrBefore) {
+				t.Errorf("UndoAllocate() = %v, want %v", ctlrAfter, ctlrBefore)
+			}
+		})
+	}
+}
+
+// createTestContoller : create an initial test quota tree with allocated consumers
+func createTestContoller(t *testing.T, treeName string) *Controller {
+
+	// create three quota nodes A[3], B[1], and C[1]
+	quotaNodeA, err := NewQuotaNode("A", &Allocation{x: []int{3}})
+	assert.NoError(t, err, "No error expected when creating quota node A")
+
+	quotaNodeB, err := NewQuotaNode("B", &Allocation{x: []int{1}})
+	assert.NoError(t, err, "No error expected when creating quota node B")
+
+	quotaNodeC, err := NewQuotaNode("C", &Allocation{x: []int{1}})
+	assert.NoError(t, err, "No error expected when creating quota node C")
+
+	// create two consumers C1[1] and C2[1]
+	consumer1 := NewConsumer("C1", treeName, "B", &Allocation{x: []int{1}}, 0, 0, false)
+	consumer2 := NewConsumer("C2", treeName, "B", &Allocation{x: []int{1}}, 0, 0, false)
+
+	// create quota tree: A -> ( B C )
+	quotaNodeA.AddChild((*tree.Node)(unsafe.Pointer(quotaNodeB)))
+	quotaNodeA.AddChild((*tree.Node)(unsafe.Pointer(quotaNodeC)))
+	quotaTreeA := NewQuotaTree(treeName, quotaNodeA, []string{"count"})
+	controller := NewController(quotaTreeA)
+
+	// allocate consumers C1 and C2
+	response1 := controller.Allocate(consumer1)
+	assert.NotNil(t, response1, "A non nill response 1 is expected")
+	assert.Equal(t, 0, len(strings.TrimSpace(response1.GetMessage())), "A empty response 1 is expected")
+
+	response2 := controller.Allocate(consumer2)
+	assert.NotNil(t, response2, "A non nill response 2 is expected")
+	assert.Equal(t, 0, len(strings.TrimSpace(response2.GetMessage())), "A empty response 2 is expected")
+
+	return controller
+}
+
+// EqualStateQuotaNodes : check if two quota nodes have similar allocation data
+func EqualStateQuotaNodes(qn1 *QuotaNode, qn2 *QuotaNode) bool {
+	return reflect.DeepEqual(qn1.GetQuota(), qn2.GetQuota()) &&
+		reflect.DeepEqual(qn1.GetAllocated(), qn2.GetAllocated()) &&
+		reflect.DeepEqual(qn1.GetConsumers(), qn2.GetConsumers())
+}
+
+// EqualStateQuotaTrees : check if two quota trees have similar allocation data
+func EqualStateQuotaTrees(qt1 *QuotaTree, qt2 *QuotaTree) bool {
+	nodeMap1 := qt1.GetNodes()
+	nodeMap2 := qt2.GetNodes()
+	if len(nodeMap1) != len(nodeMap2) {
+		return false
+	}
+	for k, qn1 := range nodeMap1 {
+		if qn2, exists := nodeMap2[k]; exists {
+			if !EqualStateQuotaNodes(qn1, qn2) {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	return true
+}
+
+// EqualStateControllers : check if two controllers have similar allocation state
+func EqualStateControllers(c1 *Controller, c2 *Controller) bool {
+	return EqualStateQuotaTrees(c1.tree, c2.tree) &&
+		reflect.DeepEqual(c1.consumers, c1.consumers) &&
+		reflect.DeepEqual(c1.preemptedConsumers, c2.preemptedConsumers) &&
+		reflect.DeepEqual(c1.preemptedConsumersArray, c2.preemptedConsumersArray)
+}

--- a/pkg/quotaplugins/quota-forest/quota-manager/quota/core/treesnapshot.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/quota/core/treesnapshot.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2023 The Multi-Cluster App Dispatcher Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"unsafe"
+
+	"k8s.io/klog/v2"
+)
+
+// TreeSnapshot : A snapshot of a quota tree that could be used to undo a consumer allocation.
+//
+// A snapshop of the tree state is taken before a consumer allocation trial, including only data
+// that could potentially change during allocation of the target consumer. Reinstating the snapshot
+// to the tree in case it is desired to undo the allocation.
+type TreeSnapshot struct {
+	// the target quota tree
+	targetTree *QuotaTree
+	// the target consumer of allocation
+	targetConsumer *Consumer
+
+	// all consumers that could potentially change due to the allocation of the target consumer
+	allChangedConsumers []*Consumer
+	// snapshot of nodes state
+	nodeStates map[string]*NodeState
+	// snapshot of consumers state
+	consumerStates map[string]*ConsumerState
+	// consumers already allocated (running)
+	activeConsumers map[string]*Consumer
+
+	// snapshot of preempted consumers
+	preemptedConsumers []string
+	// snapshot of list of preempted consumer objects
+	preemptedConsumersArray []*Consumer
+}
+
+// NodeState : snapshot data about state of a node
+type NodeState struct {
+	// the node
+	node *QuotaNode
+	// amount allocated on the node
+	allocated *Allocation
+	// list of consumers allocated on the node
+	consumers []*Consumer
+}
+
+// ConsumerState : snapshot data about state of a consumer
+type ConsumerState struct {
+	// the consumer
+	consumer *Consumer
+	// node the consumer is assigned to
+	aNode *QuotaNode
+}
+
+// NewTreeSnapshot : create a new snapshot before allocating a consumer on a quota tree
+func NewTreeSnapshot(tree *QuotaTree, consumer *Consumer) *TreeSnapshot {
+	ts := &TreeSnapshot{
+		targetTree:     tree,
+		targetConsumer: consumer,
+	}
+	ts.Reset()
+	ts.allChangedConsumers = append(ts.allChangedConsumers, consumer)
+	return ts
+}
+
+// Take : take a snapshot
+func (ts *TreeSnapshot) Take(controller *Controller, changedConsumers map[string]*Consumer) bool {
+	klog.V(4).Infof("Taking snapshot of tree %s prior to allocation of consumer %s \n",
+		ts.targetTree.GetName(), ts.targetConsumer.GetID())
+
+	// add potentially altered consumers
+	for _, c := range changedConsumers {
+		ts.allChangedConsumers = append(ts.allChangedConsumers, c)
+	}
+
+	// make a copy of active consumers
+	for cid, c := range controller.consumers {
+		ts.activeConsumers[cid] = c
+	}
+	// make a copy of preempted consumers
+	ts.preemptedConsumers = make([]string, len(controller.preemptedConsumers))
+	copy(ts.preemptedConsumers, controller.preemptedConsumers)
+	ts.preemptedConsumersArray = make([]*Consumer, len(controller.preemptedConsumersArray))
+	copy(ts.preemptedConsumersArray, controller.preemptedConsumersArray)
+
+	// copy node states for all potentially altered consumers
+	for _, c := range ts.allChangedConsumers {
+
+		// copy state of consumer; skip if already visited this consumer
+		if taken := ts.takeConsumer(c); !taken {
+			continue
+		}
+
+		// visit nodes along path from consumer leaf node to root
+		groupID := c.GetGroupID()
+		leafNode := ts.targetTree.GetLeafNode(groupID)
+		if leafNode == nil {
+			klog.V(4).Infof("Consumer %s member of unknown group %s \n", c.GetID(), groupID)
+			ts.Reset()
+			return false
+		}
+		path := leafNode.GetPathToRoot()
+		for _, n := range path {
+			node := (*QuotaNode)(unsafe.Pointer(n))
+			// make copy of node state; skip remaining nodes along path if node already visited
+			if taken := ts.takeNode(node); !taken {
+				break
+			}
+			// make a copy of node consumers
+			for _, c := range node.GetConsumers() {
+				ts.takeConsumer(c)
+			}
+		}
+	}
+	return true
+}
+
+// Reinstate : reinstate the snapshot
+func (ts *TreeSnapshot) Reinstate(controller *Controller) {
+	// reinstate consumers state
+	for _, cs := range ts.consumerStates {
+		if c := cs.consumer; c != nil {
+			c.SetNode(cs.aNode)
+		}
+	}
+
+	// reinstate nodes state
+	for _, ns := range ts.nodeStates {
+		if n := ns.node; n != nil {
+			n.SetAllocated(ns.allocated)
+			n.SetConsumers(ns.consumers)
+		}
+	}
+
+	// reinstate preempted and active consumers
+	controller.consumers = ts.activeConsumers
+	controller.preemptedConsumers = ts.preemptedConsumers
+	controller.preemptedConsumersArray = ts.preemptedConsumersArray
+
+	// reset the state of the snapshot
+	ts.Reset()
+}
+
+// takeNode : take state of a node; return false if already taken
+func (ts *TreeSnapshot) takeNode(node *QuotaNode) bool {
+	nodeID := node.GetID()
+	if _, exists := ts.nodeStates[nodeID]; exists {
+		return false
+	}
+	allocated := node.GetAllocated().Clone()
+	consumers := make([]*Consumer, len(node.GetConsumers()))
+	copy(consumers, node.GetConsumers())
+	ts.nodeStates[nodeID] = &NodeState{
+		node:      node,
+		allocated: allocated,
+		consumers: consumers,
+	}
+	return true
+}
+
+// takeConsumer : take state of consumer; return false if already taken
+func (ts *TreeSnapshot) takeConsumer(c *Consumer) bool {
+	consumerID := c.GetID()
+	if _, exists := ts.consumerStates[consumerID]; exists {
+		return false
+	}
+	ts.consumerStates[consumerID] = &ConsumerState{
+		consumer: c,
+		aNode:    c.GetNode(),
+	}
+	return true
+}
+
+// Reset : reset the snapshot data
+func (ts *TreeSnapshot) Reset() {
+	ts.allChangedConsumers = make([]*Consumer, 0)
+	ts.nodeStates = make(map[string]*NodeState)
+	ts.consumerStates = make(map[string]*ConsumerState)
+	ts.activeConsumers = make(map[string]*Consumer)
+
+	ts.preemptedConsumers = make([]string, 0)
+	ts.preemptedConsumersArray = make([]*Consumer, 0)
+}

--- a/pkg/quotaplugins/quota-forest/quota-manager/quota/core/treesnapshot_test.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/quota/core/treesnapshot_test.go
@@ -1,0 +1,268 @@
+/*
+Copyright 2023 The Multi-Cluster App Dispatcher Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test taking a snapshot
+func TestTreeSnapshot_Take(t *testing.T) {
+	type fields struct {
+		targetTree              *QuotaTree
+		targetConsumer          *Consumer
+		allChangedConsumers     []*Consumer
+		nodeStates              map[string]*NodeState
+		consumerStates          map[string]*ConsumerState
+		activeConsumers         map[string]*Consumer
+		preemptedConsumers      []string
+		preemptedConsumersArray []*Consumer
+	}
+	type args struct {
+		controller       *Controller
+		changedConsumers map[string]*Consumer
+	}
+	type results struct {
+		targetTree       *QuotaTree
+		targetConsumer   *Consumer
+		nodeStates       map[string]*NodeState
+		consumerStates   map[string]*ConsumerState
+		changedConsumers []*Consumer
+	}
+
+	// create a test controller
+	treeName := "treeA"
+	ctrl := createTestContoller(t, treeName)
+	allNodes := ctrl.tree.GetNodes()
+	allConsumers := ctrl.GetConsumers()
+
+	/*
+		TreeController:
+		QuotaTree treeA:
+		|A: isHard=false; quota=[3]; allocated=[2]; consumers={ C2 }
+		--|B: isHard=false; quota=[1]; allocated=[1]; consumers={ C1 }
+		--|C: isHard=false; quota=[1]; allocated=[0]; consumers={ }
+		Consumers:
+		Consumer: ID=C1; treeID=treeA; groupID=B; priority=0; type=0; unPreemptable=false; request=[1]; aNode=B;
+		Consumer: ID=C2; treeID=treeA; groupID=B; priority=0; type=0; unPreemptable=false; request=[1]; aNode=A;
+	*/
+
+	// create consumers
+	consumer3 := NewConsumer("C3", treeName, "B", &Allocation{x: []int{1}}, 0, 0, false)
+	consumer4 := NewConsumer("C4", treeName, "C", &Allocation{x: []int{2}}, 1, 0, false)
+
+	// define tests
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		results results
+		want    bool
+	}{
+		{
+			name: "consumer in group B",
+			fields: fields{
+				targetTree:              ctrl.tree,
+				targetConsumer:          consumer3,
+				allChangedConsumers:     []*Consumer{consumer3},
+				nodeStates:              make(map[string]*NodeState),
+				consumerStates:          make(map[string]*ConsumerState),
+				activeConsumers:         map[string]*Consumer{},
+				preemptedConsumers:      []string{},
+				preemptedConsumersArray: []*Consumer{},
+			},
+			args: args{
+				controller:       ctrl,
+				changedConsumers: nil,
+			},
+			results: results{
+				targetTree:     ctrl.tree,
+				targetConsumer: consumer3,
+				changedConsumers: []*Consumer{
+					consumer3,
+				},
+				nodeStates: map[string]*NodeState{
+					"B": {
+						node:      allNodes["B"],
+						allocated: &Allocation{x: []int{1}},
+						consumers: []*Consumer{allConsumers["C1"]},
+					},
+					"A": {
+						node:      allNodes["A"],
+						allocated: &Allocation{x: []int{2}},
+						consumers: []*Consumer{allConsumers["C2"]},
+					},
+				},
+				consumerStates: map[string]*ConsumerState{
+					"C1": {
+						consumer: allConsumers["C1"],
+						aNode:    allNodes["B"],
+					},
+					"C2": {
+						consumer: allConsumers["C2"],
+						aNode:    allNodes["A"],
+					},
+					"C3": {
+						consumer: consumer3,
+						aNode:    nil,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "consumer in group C",
+			fields: fields{
+				targetTree:              ctrl.tree,
+				targetConsumer:          consumer4,
+				allChangedConsumers:     []*Consumer{consumer4},
+				nodeStates:              make(map[string]*NodeState),
+				consumerStates:          make(map[string]*ConsumerState),
+				activeConsumers:         map[string]*Consumer{},
+				preemptedConsumers:      []string{},
+				preemptedConsumersArray: []*Consumer{},
+			},
+			args: args{
+				controller:       ctrl,
+				changedConsumers: nil,
+			},
+			results: results{
+				targetTree:     ctrl.tree,
+				targetConsumer: consumer4,
+				changedConsumers: []*Consumer{
+					consumer4,
+				},
+				nodeStates: map[string]*NodeState{
+					"C": {
+						node:      allNodes["C"],
+						allocated: &Allocation{x: []int{0}},
+						consumers: []*Consumer{},
+					},
+					"A": {
+						node:      allNodes["A"],
+						allocated: &Allocation{x: []int{2}},
+						consumers: []*Consumer{allConsumers["C2"]},
+					},
+				},
+				consumerStates: map[string]*ConsumerState{
+					"C2": {
+						consumer: allConsumers["C2"],
+						aNode:    allNodes["A"],
+					},
+					"C4": {
+						consumer: consumer4,
+						aNode:    nil,
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	// perform tests
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := &TreeSnapshot{
+				targetTree:              tt.fields.targetTree,
+				targetConsumer:          tt.fields.targetConsumer,
+				allChangedConsumers:     tt.fields.allChangedConsumers,
+				nodeStates:              tt.fields.nodeStates,
+				consumerStates:          tt.fields.consumerStates,
+				activeConsumers:         tt.fields.activeConsumers,
+				preemptedConsumers:      tt.fields.preemptedConsumers,
+				preemptedConsumersArray: tt.fields.preemptedConsumersArray,
+			}
+
+			// the function under test
+			got := ts.Take(tt.args.controller, tt.args.changedConsumers)
+
+			// check side effects of tested function
+			assert.True(t, reflect.DeepEqual(tt.fields.targetTree, tt.results.targetTree), "target tree altered")
+			assert.True(t, reflect.DeepEqual(tt.fields.targetConsumer, tt.results.targetConsumer), "target consumer altered")
+			assert.True(t, reflect.DeepEqual(tt.fields.allChangedConsumers, tt.results.changedConsumers), "all changed consumers unequal")
+			assert.True(t, reflect.DeepEqual(tt.fields.nodeStates, tt.results.nodeStates), "invalid node states")
+			assert.True(t, reflect.DeepEqual(tt.fields.consumerStates, tt.results.consumerStates), "invalid consumer states")
+
+			assert.True(t, reflect.DeepEqual(tt.fields.preemptedConsumers, []string{}), "preempted consumers altered")
+			assert.True(t, reflect.DeepEqual(tt.fields.preemptedConsumersArray, []*Consumer{}), "preempted consumers array altered")
+
+			if got != tt.want {
+				t.Errorf("TreeSnapshot.Take() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Test reinstating a snapshot
+func TestTreeSnapshot_Reinstate(t *testing.T) {
+
+	// create a test controller
+	treeName := "treeA"
+	ctrlBefore := createTestContoller(t, treeName)
+	/*
+		TreeController:
+		QuotaTree treeA:
+		|A: isHard=false; quota=[3]; allocated=[2]; consumers={ C2 }
+		--|B: isHard=false; quota=[1]; allocated=[1]; consumers={ C1 }
+		--|C: isHard=false; quota=[1]; allocated=[0]; consumers={ }
+		Consumers:
+		Consumer: ID=C1; treeID=treeA; groupID=B; priority=0; type=0; unPreemptable=false; request=[1]; aNode=B;
+		Consumer: ID=C2; treeID=treeA; groupID=B; priority=0; type=0; unPreemptable=false; request=[1]; aNode=A;
+	*/
+
+	// create consumers
+	consumer3 := NewConsumer("C3", treeName, "B", &Allocation{x: []int{1}}, 0, 0, false)
+	consumer4 := NewConsumer("C4", treeName, "C", &Allocation{x: []int{2}}, 1, 0, false)
+
+	// define tests
+	tests := []struct {
+		name           string
+		targetConsumer *Consumer
+	}{
+		{
+			name:           "Test 1",
+			targetConsumer: consumer3,
+		},
+		{
+			name:           "Test 2",
+			targetConsumer: consumer4,
+		},
+	}
+
+	// perform tests
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// take snapshot
+			ctrlAfter := createTestContoller(t, treeName)
+			ts := NewTreeSnapshot(ctrlAfter.tree, tt.targetConsumer)
+			ts.Take(ctrlAfter, nil)
+
+			// allocate a consumer
+			ctrlAfter.Allocate(tt.targetConsumer)
+
+			// the function under test
+			ts.Reinstate(ctrlAfter)
+
+			// check side effects of tested function
+			assert.True(t, EqualStateControllers(ctrlBefore, ctrlAfter),
+				"invalid reinstated state, got: %v, expected: %v", ctrlAfter, ctrlBefore)
+		})
+	}
+}

--- a/pkg/quotaplugins/quota-forest/quota-manager/quota/quotamanager.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/quota/quotamanager.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -269,24 +269,13 @@ func (m *Manager) Allocate(treeName string, consumerID string) (response *core.A
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	agent := m.agents[treeName]
-	if agent == nil {
-		return nil, fmt.Errorf("invalid tree name %s", treeName)
+	agent, consumer, err := m.preAllocate(treeName, consumerID)
+	if err == nil && agent.controller.IsConsumerAllocated(consumerID) {
+		err = fmt.Errorf("consumer %s already allocated on tree %s", consumerID, treeName)
 	}
-	consumerInfo := m.consumerInfos[consumerID]
-	if consumerInfo == nil {
-		return nil, fmt.Errorf("consumer %s does not exist, create and add first", consumerID)
-	}
-	if agent.controller.IsConsumerAllocated(consumerID) {
-		return nil, fmt.Errorf("consumer %s already allocated on tree %s", consumerID, treeName)
-	}
-	resourceNames := agent.cache.GetResourceNames()
-	consumer, err := consumerInfo.CreateTreeConsumer(treeName, resourceNames)
 	if err != nil {
-		return nil, fmt.Errorf("failure creating consumer %s on tree %s", consumerID, treeName)
+		return nil, err
 	}
-
-	klog.V(4).Infoln(consumer)
 	if m.mode == Normal {
 		response = agent.controller.Allocate(consumer)
 	} else {
@@ -296,6 +285,63 @@ func (m *Manager) Allocate(treeName string, consumerID string) (response *core.A
 		return nil, fmt.Errorf(response.GetMessage())
 	}
 	return response, err
+}
+
+// TryAllocate : try allocating a consumer on a tree
+func (m *Manager) TryAllocate(treeName string, consumerID string) (response *core.AllocationResponse, err error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	agent, consumer, err := m.preAllocate(treeName, consumerID)
+	if err == nil && agent.controller.IsConsumerAllocated(consumerID) {
+		err = fmt.Errorf("consumer %s already allocated on tree %s", consumerID, treeName)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if m.mode == Normal {
+		response = agent.controller.TryAllocate(consumer)
+	} else {
+		response = agent.controller.ForceAllocate(consumer, consumer.GetGroupID())
+	}
+	if !response.IsAllocated() {
+		return nil, fmt.Errorf(response.GetMessage())
+	}
+	return response, err
+}
+
+// UndoAllocate : undo the most recent allocation trial on a tree
+func (m *Manager) UndoAllocate(treeName string, consumerID string) (err error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	agent, consumer, err := m.preAllocate(treeName, consumerID)
+	if err != nil {
+		return err
+	}
+	if !agent.controller.UndoAllocate(consumer) {
+		return fmt.Errorf("failed undo allocate tree name %s", treeName)
+	}
+	return nil
+}
+
+// preAllocate : prepare for allocate
+func (m *Manager) preAllocate(treeName string, consumerID string) (agent *agent, consumer *core.Consumer, err error) {
+	agent = m.agents[treeName]
+	if agent == nil {
+		return nil, nil, fmt.Errorf("invalid tree name %s", treeName)
+	}
+	consumerInfo := m.consumerInfos[consumerID]
+	if consumerInfo == nil {
+		return nil, nil, fmt.Errorf("consumer %s does not exist, create and add first", consumerID)
+	}
+	resourceNames := agent.cache.GetResourceNames()
+	consumer, err = consumerInfo.CreateTreeConsumer(treeName, resourceNames)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failure creating consumer %s on tree %s", consumerID, treeName)
+	}
+	klog.V(4).Infoln(consumer)
+	return agent, consumer, nil
 }
 
 // IsAllocated : check if a consumer is allocated on a tree
@@ -425,21 +471,12 @@ func (m *Manager) AllocateForest(forestName string, consumerID string) (response
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	forestController := m.forests[forestName]
-	if forestController == nil {
-		return nil, fmt.Errorf("invalid forest name %s", forestName)
+	forestController, forestConsumer, err := m.preAllocateForest(forestName, consumerID)
+	if err == nil && forestController.IsConsumerAllocated(consumerID) {
+		err = fmt.Errorf("consumer %s already allocated on forest %s", consumerID, forestName)
 	}
-	consumerInfo := m.consumerInfos[consumerID]
-	if consumerInfo == nil {
-		return nil, fmt.Errorf("consumer %s does not exist, create and add first", consumerID)
-	}
-	if forestController.IsConsumerAllocated(consumerID) {
-		return nil, fmt.Errorf("consumer %s already allocated on forest %s", consumerID, forestName)
-	}
-	resourceNames := forestController.GetResourceNames()
-	forestConsumer, err := consumerInfo.CreateForestConsumer(forestName, resourceNames)
 	if err != nil {
-		return nil, fmt.Errorf("failure creating forest consumer %s in forest %s", consumerID, forestName)
+		return nil, err
 	}
 
 	if m.mode == Normal {
@@ -455,6 +492,68 @@ func (m *Manager) AllocateForest(forestName string, consumerID string) (response
 		return nil, fmt.Errorf(response.GetMessage())
 	}
 	return response, nil
+}
+
+// TryAllocateForest : allocate a consumer on a forest
+func (m *Manager) TryAllocateForest(forestName string, consumerID string) (response *core.AllocationResponse, err error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	forestController, forestConsumer, err := m.preAllocateForest(forestName, consumerID)
+	if err == nil && forestController.IsConsumerAllocated(consumerID) {
+		err = fmt.Errorf("consumer %s already allocated on forest %s", consumerID, forestName)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if m.mode == Normal {
+		response = forestController.TryAllocate(forestConsumer)
+	} else {
+		groupIDs := make(map[string]string)
+		for treeName, consumer := range forestConsumer.GetConsumers() {
+			groupIDs[treeName] = consumer.GetGroupID()
+		}
+		response = forestController.ForceAllocate(forestConsumer, groupIDs)
+	}
+	if !response.IsAllocated() {
+		return nil, fmt.Errorf(response.GetMessage())
+	}
+	return response, nil
+}
+
+// UndoAllocate : undo the most recent allocation trial on a tree
+func (m *Manager) UndoAllocateForest(forestName string, consumerID string) (err error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	forestController, forestConsumer, err := m.preAllocateForest(forestName, consumerID)
+	if err != nil {
+		return err
+	}
+	if !forestController.UndoAllocate(forestConsumer) {
+		return fmt.Errorf("failed undo allocate forest name %s", forestName)
+	}
+	return nil
+}
+
+// preAllocateForest : prepare for allocate forest
+func (m *Manager) preAllocateForest(forestName string, consumerID string) (forestController *core.ForestController,
+	forestConsumer *core.ForestConsumer, err error) {
+	forestController = m.forests[forestName]
+	if forestController == nil {
+		return nil, nil, fmt.Errorf("invalid forest name %s", forestName)
+	}
+	consumerInfo := m.consumerInfos[consumerID]
+	if consumerInfo == nil {
+		return nil, nil, fmt.Errorf("consumer %s does not exist, create and add first", consumerID)
+	}
+	resourceNames := forestController.GetResourceNames()
+	forestConsumer, err = consumerInfo.CreateForestConsumer(forestName, resourceNames)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failure creating forest consumer %s in forest %s", consumerID, forestName)
+	}
+	return forestController, forestConsumer, nil
 }
 
 // IsAllocatedForest : check if a consumer is allocated on a forest

--- a/pkg/quotaplugins/quota-forest/quota-manager/quota/quotamanager.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/quota/quotamanager.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022, 2203 The Multi-Cluster App Dispatcher Authors.
+Copyright 2022, 2023 The Multi-Cluster App Dispatcher Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -612,6 +612,25 @@ func (m *Manager) UpdateAll() (treeUnallocatedConsumerIDs map[string][]string,
 		err = fmt.Errorf(strings.Join(erStr, "\n"))
 	}
 	return treeUnallocatedConsumerIDs, treeResponse, forestUnallocatedConsumerIDs, forestResponse, err
+}
+
+// GetTreeController : get the tree controller for a given tree
+func (m *Manager) GetTreeController(treeName string) *core.Controller {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	if agent, exists := m.agents[treeName]; exists {
+		return agent.controller
+	}
+	return nil
+}
+
+// GetForestController : get the forest controller for a given forest
+func (m *Manager) GetForestController(forestName string) *core.ForestController {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	return m.forests[forestName]
 }
 
 // String : printout

--- a/pkg/quotaplugins/quota-forest/quota-manager/quota/quotamanagerundo_test.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/quota/quotamanagerundo_test.go
@@ -1,0 +1,659 @@
+/*
+Copyright 2023 The Multi-Cluster App Dispatcher Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package quota_test
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/project-codeflare/multi-cluster-app-dispatcher/pkg/quotaplugins/quota-forest/quota-manager/quota"
+	"github.com/project-codeflare/multi-cluster-app-dispatcher/pkg/quotaplugins/quota-forest/quota-manager/quota/core"
+	"github.com/project-codeflare/multi-cluster-app-dispatcher/pkg/quotaplugins/quota-forest/quota-manager/quota/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testTreeSpec string = `{
+		"kind": "QuotaTree",
+		"metadata": {
+		  "name": "test-tree"
+		},
+		"spec": {
+		  "resourceNames": [
+			"cpu",
+			"memory"
+		  ],
+		  "nodes": {		
+			"A": {
+			  "parent": "nil",
+			  "quota": {
+				"cpu": "12",
+				"memory": "256"
+			  }
+			},
+			"B": {
+			  "parent": "A",
+			  "quota": {
+				"cpu": "4",
+				"memory": "64"
+			  }
+			},
+			"C": {
+			  "parent": "A",
+			  "quota": {
+				"cpu": "4",
+				"memory": "64"
+			  }
+			}
+		  }
+		}
+	}`
+
+	testConsumersSpecMap = map[string]string{
+		"J-1": `{
+			"kind": "Consumer",
+			"metadata": {
+			  "name": "J-1"
+			},
+			"spec": {
+			  "id": "J-1",
+			  "trees": [
+				 {
+				   "treeName": "test-tree",
+				  "groupID": "B",
+				  "request": {
+					"cpu": 4,
+					"memory": 32
+				  }
+				}
+			  ]
+			}
+		  }`,
+		"J-2": `{
+			"kind": "Consumer",
+			"metadata": {
+			  "name": "J-2"
+			},
+			"spec": {
+			  "id": "J-2",
+			  "trees": [
+				 {
+				   "treeName": "test-tree",
+				  "groupID": "C",
+				  "request": {
+					"cpu": 4,
+					"memory": 32
+				  }
+				}
+			  ]
+			}
+		  }`,
+		"J-3": `{
+			"kind": "Consumer",
+			"metadata": {
+			  "name": "J-3"
+			},
+			"spec": {
+			  "id": "J-3",
+			  "trees": [
+				 {
+				   "treeName": "test-tree",
+				  "groupID": "C",
+				  "request": {
+					"cpu": 4,
+					"memory": 32
+				  }
+				}
+			  ]
+			}
+		  }`,
+	}
+
+	serviceTreeSpec string = `{
+		"kind": "QuotaTree",
+		"metadata": {
+		  "name": "service-tree"
+		},
+		"spec": {
+		  "resourceNames": [
+			"count"
+		  ],
+		  "nodes": {
+			"root": {
+				"parent": "nil",
+				"quota": {
+				  "count": "12"
+				}
+			  },
+			"X": {
+			  "parent": "root",
+			  "quota": {
+				"count": "5"
+			  }
+			},
+			"Y": {
+			  "parent": "root",
+			  "quota": {
+				"count": "5"
+			  }
+			},
+			"Z": {
+				"parent": "Y",
+				"quota": {
+				  "count": "6"
+				}
+			  }
+		  }
+		}
+	}`
+
+	testForestConsumersSpecMap = map[string]string{
+		"F-1": `{
+			"kind": "Consumer",
+			"metadata": {
+			  "name": "F-1"
+			},
+			"spec": {
+			  "id": "F-1",
+			  "trees": [
+				 {
+				  "treeName": "test-tree",
+				  "groupID": "B",
+				  "request": {
+					"cpu": 4,
+					"memory": 32
+				  }
+				},
+				{
+				   "treeName": "service-tree",
+				   "groupID": "X",
+				   "request": {
+					 "count": 3
+				   }
+				 }
+			  ]
+			}
+		  }`,
+	}
+)
+
+// TestTreeAllocateTryAndUndo : test TryAllocate() and UndoAllocate() on a tree
+func TestTreeAllocateTryAndUndo(t *testing.T) {
+	// define tests
+	var tests = []struct {
+		name         string
+		consumerSpec string
+		wantErr      bool
+	}{
+		{
+			name: "low priority consumer",
+			consumerSpec: `{
+				"kind": "Consumer",
+				"metadata": {
+				  "name": "J-4"
+				},
+				"spec": {
+				  "id": "J-4",
+				  "trees": [
+					 {
+					   "treeName": "test-tree",
+					  "groupID": "C",
+					  "request": {
+						"cpu": 2,
+						"memory": 16
+					  }
+					}
+				  ]
+				}
+			  }`,
+			wantErr: false,
+		},
+		{
+			name: "high priority consumer",
+			consumerSpec: `{
+				  "kind": "Consumer",
+				  "metadata": {
+					"name": "J-5"
+				  },
+				  "spec": {
+					"id": "J-5",
+					"trees": [
+					   {
+						 "treeName": "test-tree",
+						"groupID": "C",
+						"request": {
+						  "cpu": 4,
+						  "memory": 32
+						},
+						"priority": 1
+					  }
+					]
+				  }
+				}`,
+			wantErr: false,
+		},
+		{
+			name: "invalid consumer",
+			consumerSpec: `{
+				"kind": "Consumer",
+				"metadata": {
+				  "name": "J-6"
+				},
+				"spec": {
+				  "id": "J-6",
+				  "trees": [
+					 {
+					   "treeName": "other-tree",
+					  "groupID": "X",
+					  "request": {
+						"cpu": 2,
+						"memory": 16
+					  }
+					}
+				  ]
+				}
+			  }`,
+			wantErr: true,
+		},
+	}
+
+	consumersToplace := []string{"J-1", "J-2", "J-3"}
+
+	// Before keeps the state of the quota manager before applying test cases
+	qmBefore := quota.NewManager()
+	treeName := initializeQuotaManager(t, qmBefore, testTreeSpec, testConsumersSpecMap, consumersToplace)
+	ctlrBefore := qmBefore.GetTreeController(treeName)
+
+	// perform tests
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// After keeps the state of the quota manager after applying a test case
+			qmAfter := quota.NewManager()
+			initializeQuotaManager(t, qmAfter, testTreeSpec, testConsumersSpecMap, consumersToplace)
+			ctlrAfter := qmAfter.GetTreeController(treeName)
+			assert.True(t, core.EqualStateControllers(ctlrBefore, ctlrAfter),
+				"Initial tree allocation states should be same; got: %v; want: %v",
+				ctlrAfter, ctlrBefore)
+
+			// try allocate test consumer
+			consumerID, err := createConsumer(qmAfter, tt.consumerSpec)
+			if err != nil && !tt.wantErr {
+				t.Errorf("Error creating consumer %s", consumerID)
+			}
+			qmAfter.TryAllocate(treeName, consumerID)
+			if qmAfter.IsAllocated(treeName, consumerID) {
+				assert.False(t, core.EqualStateControllers(ctlrBefore, ctlrAfter),
+					"Tree allocation states should be different after test consumer %s allocation; got: %v; notWant: %v",
+					consumerID, ctlrAfter, ctlrBefore)
+			} else {
+				assert.True(t, core.EqualStateControllers(ctlrBefore, ctlrAfter),
+					"Tree allocation states should be same if consumer %s is not allocated; got: %v; want: %v",
+					consumerID, ctlrAfter, ctlrBefore)
+			}
+
+			// simulate computation delay between try allocating and undoing the allocation
+			time.Sleep(10 * time.Millisecond)
+
+			// undo allocate of test consumer
+			err = qmAfter.UndoAllocate(treeName, consumerID)
+			if err != nil && !tt.wantErr {
+				t.Errorf("Error in undo allocate consumer %s", consumerID)
+			}
+			assert.True(t, core.EqualStateControllers(ctlrBefore, ctlrAfter),
+				"Unequal tree allocation state after undo allocation %s; got: %v; want: %v",
+				consumerID, ctlrAfter, ctlrBefore)
+		})
+	}
+}
+
+// TestForestAllocateTryAndUndo : test TryAllocate() and UndoAllocate() on a forest
+func TestForestAllocateTryAndUndo(t *testing.T) {
+	forestName := "testForest"
+	forestTreesSpecs := []string{testTreeSpec, serviceTreeSpec}
+	var err error
+	// define tests
+	var tests = []struct {
+		name         string
+		consumerSpec string
+		wantErr      bool
+	}{
+		{
+			name: "valid consumer",
+			consumerSpec: `{
+				"kind": "Consumer",
+				"metadata": {
+				  "name": "F-5"
+				},
+				"spec": {
+				  "id": "F-5",
+				  "trees": [
+					 {
+					  "treeName": "test-tree",
+					  "groupID": "B",
+					  "request": {
+						"cpu": 4,
+						"memory": 32
+					  }
+					},
+					{
+					   "treeName": "service-tree",
+					   "groupID": "X",
+					   "request": {
+						 "count": 3
+					   }
+					 }
+				  ]
+				}
+			  }`,
+			wantErr: false,
+		},
+		{
+			name: "invalid consumer",
+			consumerSpec: `{
+				"kind": "Consumer",
+				"metadata": {
+				  "name": "F-6"
+				},
+				"spec": {
+				  "id": "F-6",
+				  "trees": [
+					 {
+					  "treeName": "test-tree",
+					  "groupID": "F",
+					  "request": {
+						"cpu": 2,
+						"memory": 16
+					  }
+					},
+					{
+					   "treeName": "unknown-tree",
+					   "groupID": "X",
+					   "request": {
+						 "count": 3
+					   }
+					 }
+				  ]
+				}
+			  }`,
+			wantErr: true,
+		},
+	}
+
+	consumersToplace := []string{"F-1"}
+
+	// Before keeps the state of the quota manager before applying test cases
+	qmBefore := quota.NewManager()
+	initializeForestQuotaManager(t, qmBefore, forestName, forestTreesSpecs, testForestConsumersSpecMap,
+		consumersToplace)
+	ctlrBefore := qmBefore.GetForestController(forestName)
+
+	// perform tests
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// After keeps the state of the quota manager after applying a test case
+			qmAfter := quota.NewManager()
+			initializeForestQuotaManager(t, qmAfter, forestName, forestTreesSpecs, testForestConsumersSpecMap,
+				consumersToplace)
+			ctlrAfter := qmAfter.GetForestController(forestName)
+
+			// try allocate test consumer
+			var cinfo *quota.ConsumerInfo
+			cinfo, err = quota.NewConsumerInfoFromString(tt.consumerSpec)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("Error creating consumer from spec")
+				}
+				return
+			}
+			consumerID := cinfo.GetID()
+			var added bool
+			added, err = qmAfter.AddConsumer(cinfo)
+			assert.True(t, added && err == nil, "Error adding consumer %s", consumerID)
+			_, err = qmAfter.TryAllocateForest(forestName, consumerID)
+			assert.True(t, err == nil || tt.wantErr,
+				"Error allocating consumer %s on forest %s", consumerID, forestName)
+			if qmAfter.IsAllocatedForest(forestName, consumerID) {
+				assert.False(t, core.EqualStateForestControllers(ctlrBefore, ctlrAfter),
+					"Forest allocation states should be different after test consumer %s allocation", consumerID)
+			} else {
+				assert.True(t, core.EqualStateForestControllers(ctlrBefore, ctlrAfter),
+					"Forest allocation states should be same if consumer %s is not allocated, want %v, got %v",
+					consumerID, ctlrBefore, ctlrAfter)
+			}
+
+			// simulate computation delay between try allocating and undoing the allocation
+			time.Sleep(10 * time.Millisecond)
+
+			// undo allocate of test consumer
+			err = qmAfter.UndoAllocateForest(forestName, consumerID)
+			if err != nil {
+				t.Errorf("Error in undo forest allocate consumer %s", consumerID)
+			}
+			assert.True(t, core.EqualStateForestControllers(ctlrBefore, ctlrAfter),
+				"Unequal forest allocation state after undo allocation %s", consumerID)
+		})
+	}
+}
+
+// initializeQuotaManager : helper to create an initial test quota tree and allocate a set of consumers
+func initializeQuotaManager(t *testing.T, qm *quota.Manager, treeSpec string, testConsumersSpecMap map[string]string,
+	consumersToplace []string) string {
+	treeName, err := qm.AddTreeFromString(treeSpec)
+	assert.NoError(t, err, "Error creating tree from spec %s", treeName)
+	qm.SetMode(quota.Normal)
+
+	// place some consumers
+	for _, consumerID := range consumersToplace {
+		cSpec := testConsumersSpecMap[consumerID]
+		assert.True(t, len(cSpec) != 0, "Error creating consumer %s, not in testForestConsumersSpecMap", consumerID)
+		_, err := createConsumer(qm, cSpec)
+		assert.NoError(t, err, "Error creating consumer from spec %s", treeName)
+		_, err = qm.Allocate(treeName, consumerID)
+		assert.NoError(t, err,
+			"Error allocating consumer %s on tree %s", consumerID, treeName)
+	}
+	return treeName
+}
+
+// initializeForestQuotaManager : helper to create an initial test quota forest and allocate a set of forest consumers
+func initializeForestQuotaManager(t *testing.T, qm *quota.Manager, forestName string, treeSpecs []string,
+	testConsumersSpecMap map[string]string, consumersToplace []string) {
+
+	// add forest
+	qm.AddForest(forestName)
+	for _, treeSpec := range treeSpecs {
+		treeName, err := qm.AddTreeFromString(treeSpec)
+		assert.NoError(t, err, "Error creating tree from spec %s", treeName)
+		qm.AddTreeToForest(forestName, treeName)
+	}
+	qm.SetMode(quota.Normal)
+
+	// create some consumers
+	for _, cID := range consumersToplace {
+		cSpec := testForestConsumersSpecMap[cID]
+		assert.True(t, len(cSpec) != 0, "Error creating consumer %s, not in testForestConsumersSpecMap", cID)
+		cinfo, err := quota.NewConsumerInfoFromString(cSpec)
+		assert.NoError(t, err, "Error creating consumer from spec %s", cID)
+
+		consumerID := cinfo.GetID()
+		added, err := qm.AddConsumer(cinfo)
+		assert.True(t, added && err == nil, "Error adding consumer %s", consumerID)
+
+		_, err = qm.AllocateForest(forestName, consumerID)
+		assert.NoError(t, err,
+			"Error allocating consumer %s on forest %s", consumerID, forestName)
+	}
+}
+
+// createConsumer : create a consumer from specification and add to quota manager
+func createConsumer(qm *quota.Manager, consumerSpec string) (string, error) {
+	cinfo, err := quota.NewConsumerInfoFromString(consumerSpec)
+	if err != nil {
+		return "", err
+	}
+	consumerID := cinfo.GetID()
+	if added, err := qm.AddConsumer(cinfo); !added || err != nil {
+		return consumerID, err
+	}
+	return consumerID, nil
+}
+
+func TestQuotaManagerParallelTryUndoAllocation(t *testing.T) {
+	forestName := "unit-test-1"
+	qmManagerUnderTest := quota.NewManager()
+
+	err := qmManagerUnderTest.AddForest(forestName)
+	assert.NoError(t, err, "No error expected when adding a forest")
+	testTreeName, err := qmManagerUnderTest.AddTreeFromString(
+		`{
+			"kind": "QuotaTree",
+			"metadata": {
+			  "name": "test-tree"
+			},
+			"spec": {
+			  "resourceNames": [
+				"cpu",
+				"memory"
+			  ],
+			  "nodes": {		
+				"root": {
+				  "parent": "nil",
+				  "hard": "true",
+				  "quota": {
+					"cpu": "10",
+					"memory": "256"
+				  }
+				},		
+				"gold": {
+				  "parent": "root",
+				  "hard": "true",
+				  "quota": {
+					"cpu": "10",
+					"memory": "256"
+				  }
+				}
+			  }
+			}
+		}`)
+	if err != nil {
+		assert.Fail(t, "No error expected when adding a tree to forest")
+	}
+	err = qmManagerUnderTest.AddTreeToForest(forestName, testTreeName)
+	assert.NoError(t, err, "No error expected when adding a tree from forest")
+	modeSet := qmManagerUnderTest.SetMode(quota.Normal)
+	assert.True(t, modeSet, "Setting the mode should not fail.")
+
+	tryUndoLock := sync.RWMutex{}
+
+	// Define the test table
+	var tests = []struct {
+		name     string
+		consumer utils.JConsumer
+	}{
+		// the table itself
+		{"Gold consumer 1",
+			utils.JConsumer{
+				Kind: "Consumer",
+				MetaData: utils.JMetaData{
+					Name: "gold-consumer-data-1",
+				},
+				Spec: utils.JConsumerSpec{
+					ID: "gold-consumer-1",
+					Trees: []utils.JConsumerTreeSpec{
+						{
+							TreeName: testTreeName,
+							GroupID:  "gold",
+							Request: map[string]int{
+								"cpu":    4,
+								"memory": 4,
+								"gpu":    0,
+							},
+							Priority:      0,
+							CType:         0,
+							UnPreemptable: false,
+						},
+					},
+				},
+			},
+		},
+		// the table itself
+		{"Gold consumer 2",
+			utils.JConsumer{
+				Kind: "Consumer",
+				MetaData: utils.JMetaData{
+					Name: "gold-consumer-data-2",
+				},
+				Spec: utils.JConsumerSpec{
+					ID: "gold-consumer-2",
+					Trees: []utils.JConsumerTreeSpec{
+						{
+							TreeName: testTreeName,
+							GroupID:  "gold",
+							Request: map[string]int{
+								"cpu":    4,
+								"memory": 4,
+								"gpu":    0,
+							},
+							Priority:      0,
+							CType:         0,
+							UnPreemptable: false,
+						},
+					},
+				},
+			},
+		},
+	}
+	// Execute tests in parallel
+	for _, tc := range tests {
+		tc := tc // capture range variable
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Get list of quota management tree IDs
+			qmTreeIDs := qmManagerUnderTest.GetTreeNames()
+
+			consumerInfo, err := quota.NewConsumerInfo(tc.consumer)
+			assert.NoError(t, err, "No error expected when building consumer")
+			assert.Contains(t, qmTreeIDs, tc.consumer.Spec.Trees[0].TreeName)
+
+			added, err := qmManagerUnderTest.AddConsumer(consumerInfo)
+			assert.NoError(t, err, "No error expected when adding consumer")
+			assert.True(t, added, "Consumer is expected to be added")
+
+			// TryAllocate() and UndoAllocate() should be atomic
+			tryUndoLock.Lock()
+			defer tryUndoLock.Unlock()
+
+			response, err := qmManagerUnderTest.TryAllocate(tc.consumer.Spec.Trees[0].TreeName, consumerInfo.GetID())
+			if !assert.NoError(t, err, "No error expected when calling TryAllocate consumer") {
+				assert.Equal(t, 0, len(strings.TrimSpace(response.GetMessage())), "A empty response is expected")
+				assert.True(t, response.IsAllocated(), "The allocation should succeed")
+			}
+
+			//simulate a long running consumer that has quota allocated
+			time.Sleep(10 * time.Millisecond)
+
+			err = qmManagerUnderTest.UndoAllocate(tc.consumer.Spec.Trees[0].TreeName, consumerInfo.GetID())
+			assert.NoError(t, err, "No error expected when calling UndoAllocate consumer")
+		})
+	}
+}

--- a/pkg/quotaplugins/quota-forest/quota-manager/quota/quotamanagerundo_test.go
+++ b/pkg/quotaplugins/quota-forest/quota-manager/quota/quotamanagerundo_test.go
@@ -328,7 +328,7 @@ func TestTreeAllocateTryAndUndo(t *testing.T) {
 func TestForestAllocateTryAndUndo(t *testing.T) {
 	forestName := "testForest"
 	forestTreesSpecs := []string{testTreeSpec, serviceTreeSpec}
-	var err error
+
 	// define tests
 	var tests = []struct {
 		name         string
@@ -410,6 +410,7 @@ func TestForestAllocateTryAndUndo(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			var err error
 			// After keeps the state of the quota manager after applying a test case
 			qmAfter := quota.NewManager()
 			initializeForestQuotaManager(t, qmAfter, forestName, forestTreesSpecs, testForestConsumersSpecMap,


### PR DESCRIPTION
Two calls are added to try to allocate a consumer, and if unaccepted, to undo the effect of the allocation trial. If the trial is accepted, no further action is needed. Otherwise, the undo has to be called right after the try allocation, without making any calls to change the trees or allocate/deallocate consumers. These operations are intended only during Normal mode.
  - `TryAllocate(treeName, consumerID)`
  - `UndoAllocate(treeName, consumerID)`
  - `TryAllocateForest(forestName, consumerID)`
  - `UndoAllocateForest(forestName, consumerID)`