### PR TITLE
Updates to use a hardcoded port for the kubeproxy.

### DIFF
--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -47,8 +47,6 @@ export KUTTL_VERSION=0.15.0
 export KUTTL_OPTIONS=${TEST_KUTTL_OPTIONS}
 export KUTTL_TEST_SUITES=("${ROOT_DIR}/test/kuttl-test.yaml" "${ROOT_DIR}/test/kuttl-test-deployment-03.yaml" "${ROOT_DIR}/test/kuttl-test-deployment-02.yaml" "${ROOT_DIR}/test/kuttl-test-deployment-01.yaml")
 DUMP_LOGS="true"
-export KUBE_PROXY_PORT=${KUBE_PROXY_PORT:-8888}
-
 
 function update_test_host {
   
@@ -381,22 +379,25 @@ function extend-resources {
     # This is intended to allow testing of GPU specific features such as histograms.
 
     # Start communication with cluster
-    kubectl proxy -p ${KUBE_PROXY_PORT} 2>&1 &
+    kubectl proxy --port=0 > .port.dat 2>&1 &
     proxy_pid=$!
+
     echo "Starting background proxy connection (pid=${proxy_pid})..."
     echo "Waiting for proxy process to start."
     sleep 30
 
-    curl -s 127.0.0.1:${KUBE_PROXY_PORT} > /dev/null 2>&1
+    kube_proxy_port=$(cat .port.dat | awk '{split($5, substrings, ":"); print substrings[2]}')
+    curl -s 127.0.0.1:${kube_proxy_port} > /dev/null 2>&1
 
     if [[ ! $? -eq 0 ]]; then
         echo "Calling 'kubectl proxy' did not create a successful connection to the kubelet needed to patch the nodes. Exiting."
         kill -9 ${proxy_pid}
         exit 1
     else
-        echo "Connected to the kubelet for patching the nodes"
+        echo "Connected to the kubelet for patching the nodes. Using port ${kube_proxy_port}."
     fi
 
+    rm .port.dat
 
     # Variables
     resource_name="nvidia.com~1gpu"
@@ -410,7 +411,7 @@ function extend-resources {
         patching_status=$(curl -s --header "Content-Type: application/json-patch+json" \
                                 --request PATCH \
                                 --data '[{"op": "add", "path": "/status/capacity/'${resource_name}'", "value": "'${resource_count}'"}]' \
-                                http://localhost:${KUBE_PROXY_PORT}/api/v1/nodes/${node_name}/status | jq -r '.status')
+                                http://localhost:${kube_proxy_port}/api/v1/nodes/${node_name}/status | jq -r '.status')
 
         if [[ ${patching_status} == "Failure" ]]; then
             echo "Failed to patch node '${node_name}' with GPU resources"
@@ -423,6 +424,7 @@ function extend-resources {
     # Stop communication with cluster
     echo "Killing proxy (pid=${proxy_pid})..."
     kill -9 ${proxy_pid}
+
     # Run kuttl tests to confirm GPUs were added correctly
     kuttl_test="${ROOT_DIR}/test/kuttl-test-extended-resources.yaml"
     echo "kubectl kuttl test --config ${kuttl_test}"


### PR DESCRIPTION
# Issue link
Fixes #516

# What changes have been made
* Hardcoded the port number to be used when starting a local kubeproxy in the end 2 end script.

# Verification steps
Ran the script on my local development manchine.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change
