### PR TITLE
Use receive-only channels for stopping controllers

### DIFF
--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -1407,7 +1407,7 @@ func (qjm *XController) backoff(ctx context.Context, q *arbv1.AppWrapper, reason
 }
 
 // Run starts AppWrapper Controller
-func (cc *XController) Run(stopCh chan struct{}) {
+func (cc *XController) Run(stopCh <-chan struct{}) {
 	go cc.appwrapperInformer.Informer().Run(stopCh)
 
 	go cc.qjobResControls[arbv1.ResourceTypePod].Run(stopCh)

--- a/pkg/controller/queuejobdispatch/queuejobagent.go
+++ b/pkg/controller/queuejobdispatch/queuejobagent.go
@@ -153,7 +153,7 @@ func (cc *JobClusterAgent) deleteQueueJob(obj interface{}) {
 	cc.agentEventQueue.Add(qj)
 }
 
-func (qa *JobClusterAgent) Run(stopCh chan struct{}) {
+func (qa *JobClusterAgent) Run(stopCh <-chan struct{}) {
 	go qa.jobInformer.Informer().Run(stopCh)
 	cache.WaitForCacheSync(stopCh, qa.jobSynced)
 }


### PR DESCRIPTION
This follows the idiomatic syntax, and eases the re-use the MCAD controllers.