### PR TITLE
Update CodeFlare operator to latest MCAD dev after every merged commit

### DIFF
--- a/.github/workflows/update-codeflare-operator.yml
+++ b/.github/workflows/update-codeflare-operator.yml
@@ -1,0 +1,60 @@
+name: Update CodeFlare operator with latest changes from MCAD
+
+on:
+  workflow_run:
+    workflows: [Build and Push dev MCAD image into Quay]
+    types:
+      - completed
+
+jobs:
+  update-codeflare-operator:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' && github.repository == 'project-codeflare/multi-cluster-app-dispatcher'
+
+    steps:
+      - name: checkout MCAD code
+        uses: actions/checkout@v3
+        with:
+          path: 'mcad'
+
+      - name: Store latest MCAD Git SHA
+        run: |
+          echo "GIT_COMMIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
+        working-directory: mcad
+
+      - name: checkout CodeFlare operator code
+        uses: actions/checkout@v3
+        with:
+          repository: 'project-codeflare/codeflare-operator'
+          token: ${{ env.GITHUB_TOKEN }}
+          path: operator
+        env:
+          GITHUB_TOKEN: ${{ secrets.CODEFLARE_MACHINE_ACCOUNT_TOKEN }}
+
+      - name: Update CodeFlare operator code to use latest MCAD version
+        run: |
+          sed -i -E "s/(.*MCAD_VERSION \?= ).*/\1${{ env.GIT_COMMIT_SHA }}/" Makefile
+          sed -i -E "s/(.*MCAD_REF \?= ).*/\1dev/" Makefile
+          make modules
+          go mod tidy
+        working-directory: operator
+
+      - name: Commit CodeFlare operator changes in the code back to repository
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update MCAD to latest dev
+          create_branch: true
+          repository: operator
+          branch: dev
+          push_options: '--force'
+
+      - name: Create a PR in CodeFlare operator repo with code changes if not opened yet
+        run: |
+          if [[ $(gh pr view dev) && $(gh pr view dev --json state --jq .state) == "OPEN" ]]; then
+            echo "PR already opened"
+          else
+            gh pr create --base "main" --fill --head dev
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.CODEFLARE_MACHINE_ACCOUNT_TOKEN }}
+        working-directory: operator


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
Fixes https://github.com/project-codeflare/multi-cluster-app-dispatcher/issues/574

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
After every merged commit (once `Build and Push dev MCAD image into Quay` finishes) the workflow updates MCAD dependencies in CodeFlare operator repo and open a PR with changes. The PR will then run all tests to make sure that MCAD doesn't contain any changes which could break integration between MCAD and CodeFlare operator.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
N/A
Tested locally, the result PR can be found here - https://github.com/project-codeflare/codeflare-operator/pull/233

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change
