### PR TITLE
Update queuejob_controller_ex.go

### DIFF
--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -245,8 +245,11 @@ func NewJobController(config *rest.Config, serverOption *options.ServerOption) *
 	cc.agentList = []string{}
 	for _, agentconfig := range strings.Split(serverOption.AgentConfigs, ",") {
 		agentData := strings.Split(agentconfig, ":")
-		cc.agentMap["/root/kubernetes/"+agentData[0]] = queuejobdispatch.NewJobClusterAgent(agentconfig, cc.agentEventQueue)
-		cc.agentList = append(cc.agentList, "/root/kubernetes/"+agentData[0])
+		jobClusterAgent := queuejobdispatch.NewJobClusterAgent(agentconfig, cc.agentEventQueue)
+		if jobClusterAgent != nil {
+			cc.agentMap["/root/kubernetes/"+agentData[0]] = jobClusterAgent
+			cc.agentList = append(cc.agentList, "/root/kubernetes/"+agentData[0])
+		}		
 	}
 
 	if cc.isDispatcher && len(cc.agentMap) == 0 {


### PR DESCRIPTION
# Issue link
N/A

# What changes have been made
BUG, when creating agent config fails, the code is not observing the error status (nil). The fix is to skip adding the jobClusterAgent to the list and to the map if the NewJobClusterAgent returns nil. 

# Verification steps
Manual test

## Checks
- [X] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] Testing is not required for this change
