### PR TITLE
Stop CI Build when e2e test case fails

### DIFF
--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -466,7 +466,7 @@ setup-mcad-env
 # MCAD with quotamanagement options is started by kuttl-tests
 kuttl-tests
 mcad-up
-go test ./test/e2e -v -timeout 130m -count=1
+go test ./test/e2e -v -timeout 130m -count=1 -ginkgo.failFast
 RC=$?
 if [ ${RC} -eq 0 ]
 then


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
closes https://github.com/project-codeflare/multi-cluster-app-dispatcher/issues/595
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Added ginkgo failfast condition to stop the build when the e2e ginkgo test fails to save build time.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change
