### PR TITLE
renamed variable to avoid double negation

### DIFF
--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -521,9 +521,9 @@ func (qjm *XController) GetQueueJobsEligibleForPreemption() []*arbv1.AppWrapper 
 				awDispatchDurationLimit := value.Spec.SchedSpec.DispatchDuration.Limit
 				dispatchDuration := value.Status.ControllerFirstDispatchTimestamp.Add(time.Duration(awDispatchDurationLimit) * time.Second)
 				currentTime := time.Now()
-				hasDispatchTimeNotExceeded := currentTime.Before(dispatchDuration)
+				dispatchTimeExceeded := !currentTime.Before(dispatchDuration)
 
-				if !hasDispatchTimeNotExceeded {
+				if dispatchTimeExceeded {
 					klog.V(8).Infof("Appwrapper Dispatch limit exceeded, currentTime %v, dispatchTimeInSeconds %v", currentTime, dispatchDuration)
 					value.Spec.SchedSpec.DispatchDuration.Overrun = true
 					qjobs = append(qjobs, value)


### PR DESCRIPTION
# Issue link
NONE

# What changes have been made
I changed a variable to avoid a double negative in a conditional

# Verification steps
I don't think this needs to be tested as these are the only two instances of the variable, but lmk if you think otherwise

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [x] Testing is not required for this change
