### PR TITLE
Update mcad kuberay example

### DIFF
--- a/doc/usage/examples/kuberay/config/aw-raycluster-1.yaml
+++ b/doc/usage/examples/kuberay/config/aw-raycluster-1.yaml
@@ -1,7 +1,7 @@
 apiVersion: mcad.ibm.com/v1beta1
 kind: AppWrapper
 metadata:
-  name: raycluster-complete
+  name: raycluster-complete-1
   namespace: default
 spec:
   resources:
@@ -30,7 +30,7 @@ spec:
           labels:
             controller-tools.k8s.io: "1.0"
             # A unique identifier for the head node and workers of this cluster.
-          name: raycluster-complete
+          name: raycluster-complete-1
         spec:
           rayVersion: '2.5.0'
           # Ray head pod configuration

--- a/doc/usage/examples/kuberay/config/aw-raycluster-1.yaml
+++ b/doc/usage/examples/kuberay/config/aw-raycluster-1.yaml
@@ -7,18 +7,31 @@ spec:
   resources:
     GenericItems:
     - replicas: 1
-      custompodresources: # Optional section that specifies resource requirements
-                          # for non-standard k8s resources, follows same format as
-                          # that of standard k8s resources.
-      - replicas: 2 # because AppWrappers are generic they must define the resultant pods that will be needed
-                    # to fulfill a request as the request values cannot be reliably extracted from the
-                    # generictemplate below
+      custompodresources:
+      # Optional section that specifies resource requirements
+      # for non-standard k8s resources, follows same format as
+      # that of standard k8s resources.
+      # Each item in the custompodresources stanza should include resources consumed by target Item.
+      # In this example, the 2 items correspond to 1 Ray head pod and 1 Ray worker pod
+      - replicas: 1
+        limits:
+          cpu: 2
+          memory: 8G
+          nvidia.com/gpu: 0
+        requests:
+          cpu: 2
+          memory: 8G
+          nvidia.com/gpu: 0
+      # The replica should match the number of worker pods
+      - replicas: 1
+        limits:
+          cpu: 8
+          memory: 8G
+          nvidia.com/gpu: 0
         requests:
           cpu: 8
-          memory: 512Mi
-        limits:
-          cpu: 10
-          memory: 1G
+          memory: 8G
+          nvidia.com/gpu: 0
       generictemplate:
         # The resource requests and limits in this config are too small for production!
         # For examples with more realistic resource configuration, see
@@ -75,15 +88,13 @@ spec:
                   # entire Kubernetes node on which it is scheduled.
                   resources:
                     limits:
-                      cpu: "1"
-                      memory: "2G"
+                      cpu: "2"
+                      memory: "8G"
                     requests:
                       # For production use-cases, we recommend specifying integer CPU reqests and limits.
                       # We also recommend setting requests equal to limits for both CPU and memory.
-                      # For this example, we use a 500m CPU request to accomodate resource-constrained local
-                      # Kubernetes testing environments such as KinD and minikube.
-                      cpu: "500m"
-                      memory: "2G"
+                      cpu: "2"
+                      memory: "8G"
                 volumes:
                   - name: ray-logs
                     emptyDir: {}
@@ -131,20 +142,16 @@ spec:
                   # entire Kubernetes node on which it is scheduled.
                   resources:
                     limits:
-                      cpu: "1"
-                      memory: "1G"
+                      cpu: "8"
+                      memory: "8G"
                     # For production use-cases, we recommend specifying integer CPU reqests and limits.
                     # We also recommend setting requests equal to limits for both CPU and memory.
-                    # For this example, we use a 500m CPU request to accomodate resource-constrained local
-                    # Kubernetes testing environments such as KinD and minikube.
                     requests:
                       # For production use-cases, we recommend specifying integer CPU reqests and limits.
                       # We also recommend setting requests equal to limits for both CPU and memory.
-                      # For this example, we use a 500m CPU request to accomodate resource-constrained local
-                      # Kubernetes testing environments such as KinD and minikube.
-                      cpu: "500m"
+                      cpu: "8"
                       # For production use-cases, we recommend allocating at least 8Gb memory for each Ray container.
-                      memory: "1G"
+                      memory: "8G"
                 # use volumes
                 # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
                 volumes:

--- a/doc/usage/examples/kuberay/config/aw-raycluster.yaml
+++ b/doc/usage/examples/kuberay/config/aw-raycluster.yaml
@@ -7,18 +7,31 @@ spec:
   resources:
     GenericItems:
     - replicas: 1
-      custompodresources: # Optional section that specifies resource requirements
-                          # for non-standard k8s resources, follows same format as
-                          # that of standard k8s resources.
-      - replicas: 2 # because AppWrappers are generic they must define the resultant pods that will be needed
-                    # to fulfill a request as the request values cannot be reliably extracted from the
-                    # generictemplate below
+      custompodresources:
+      # Optional section that specifies resource requirements
+      # for non-standard k8s resources, follows same format as
+      # that of standard k8s resources.
+      # Each item in the custompodresources stanza should include resources consumed by target Item.
+      # In this example, the 2 items correspond to 1 Ray head pod and 1 Ray worker pod
+      - replicas: 1
+        limits:
+          cpu: 2
+          memory: 8G
+          nvidia.com/gpu: 0
+        requests:
+          cpu: 2
+          memory: 8G
+          nvidia.com/gpu: 0
+      # The replica should match the number of worker pods
+      - replicas: 1
+        limits:
+          cpu: 8
+          memory: 8G
+          nvidia.com/gpu: 0
         requests:
           cpu: 8
-          memory: 512Mi
-        limits:
-          cpu: 10
-          memory: 1G
+          memory: 8G
+          nvidia.com/gpu: 0
       generictemplate:
         # The resource requests and limits in this config are too small for production!
         # For examples with more realistic resource configuration, see
@@ -75,15 +88,13 @@ spec:
                   # entire Kubernetes node on which it is scheduled.
                   resources:
                     limits:
-                      cpu: "1"
-                      memory: "2G"
+                      cpu: "2"
+                      memory: "8G"
                     requests:
                       # For production use-cases, we recommend specifying integer CPU reqests and limits.
                       # We also recommend setting requests equal to limits for both CPU and memory.
-                      # For this example, we use a 500m CPU request to accomodate resource-constrained local
-                      # Kubernetes testing environments such as KinD and minikube.
-                      cpu: "500m"
-                      memory: "2G"
+                      cpu: "2"
+                      memory: "8G"
                 volumes:
                   - name: ray-logs
                     emptyDir: {}
@@ -131,20 +142,16 @@ spec:
                   # entire Kubernetes node on which it is scheduled.
                   resources:
                     limits:
-                      cpu: "1"
-                      memory: "1G"
+                      cpu: "8"
+                      memory: "8G"
                     # For production use-cases, we recommend specifying integer CPU reqests and limits.
                     # We also recommend setting requests equal to limits for both CPU and memory.
-                    # For this example, we use a 500m CPU request to accomodate resource-constrained local
-                    # Kubernetes testing environments such as KinD and minikube.
                     requests:
                       # For production use-cases, we recommend specifying integer CPU reqests and limits.
                       # We also recommend setting requests equal to limits for both CPU and memory.
-                      # For this example, we use a 500m CPU request to accomodate resource-constrained local
-                      # Kubernetes testing environments such as KinD and minikube.
-                      cpu: "500m"
+                      cpu: "8"
                       # For production use-cases, we recommend allocating at least 8Gb memory for each Ray container.
-                      memory: "1G"
+                      memory: "8G"
                 # use volumes
                 # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
                 volumes:

--- a/doc/usage/examples/kuberay/kuberay-mcad.md
+++ b/doc/usage/examples/kuberay/kuberay-mcad.md
@@ -32,8 +32,7 @@ This integration will help in queuing on [kuberay](https://github.com/ray-projec
 
     - OpenShift cluster:
 
-        MCAD and KubeRay Operators are part of the CodeFlare stack which provides a simple, user-friendly abstraction for scaling,
-queuing and resource management of distributed AI/ML and Python workloads. Please follow the `Distributed Workloads` [Quick-Start](https://github.com/opendatahub-io/distributed-workloads/blob/main/Quick-Start.md) for installation.
+        On OpenShift,  MCAD and KubeRay are already part of the Open Data Hub Distributed Workload Stack. The stack provides a simple, user-friendly abstraction for scaling, queuing and resource management of distributed AI/ML and Python workloads. Please follow the Quick Start in the [Distributed Workloads](https://github.com/opendatahub-io/distributed-workloads) for installation.
 
 
 #### Steps

--- a/doc/usage/examples/kuberay/kuberay-mcad.md
+++ b/doc/usage/examples/kuberay/kuberay-mcad.md
@@ -4,13 +4,55 @@ This integration will help in queuing on [kuberay](https://github.com/ray-projec
 
 #### Prerequisites
 
-- kubernetes or Openshift cluster 
-- Install MCAD using instructions present under `deployment` directory
-- Make sure MCAD has clusterrole to create ray resources, please patch using configuration file present in `config` directory with name `xqueuejob-controller.yaml`
+- Kubernetes(see [KinD](https://helm.sh/docs/intro/install/)) or Openshift cluster(see [OpenShift Local](https://developers.redhat.com/products/openshift-local/overview))
+- Kubernetes client tools such as [kubectl](https://kubernetes.io/docs/tasks/tools/) or [OpenShift CLI](https://docs.openshift.com/container-platform/4.13/cli_reference/openshift_cli/getting-started-cli.html)
+- [Helm](https://helm.sh/docs/intro/install/)
+- Install MCAD and KubeRay operators:
+    - KinD cluster:
+
+        Install the stable release of MCAD opeartor from local charts
+        ```bash
+        git clone https://github.com/project-codeflare/multi-cluster-app-dispatcher
+        cd multi-cluster-app-dispatcher
+        helm install mcad --set image.repository=quay.io/project-codeflare/mcad-controller --set image.tag=stable deployment/mcad-controller
+        ```
+
+        Make sure MCAD has clusterrole to create ray resources, please patch using [xqueuejob-controller.yaml](doc/usage/examples/kuberay/config/xqueuejob-controller.yaml). For example:
+        ```
+        kubectl apply -f doc/usage/examples/kuberay/config/xqueuejob-controller.yaml
+        ```
+
+        See [deployment.md](../../../../doc/deploy/deployment.md) for more options.
+
+        Install kuberay operator using the [instructions](https://github.com/ray-project/kuberay#quick-start). For example, install kuberay v0.6.0 from remote helm repo:
+        ```
+        helm repo add kuberay https://ray-project.github.io/kuberay-helm/
+        helm install kuberay-operator kuberay/kuberay-operator --version 0.6.0
+        ```
+
+    - OpenShift cluster:
+
+        MCAD and KubeRay Operators are part of the CodeFlare stack which provides a simple, user-friendly abstraction for scaling,
+queuing and resource management of distributed AI/ML and Python workloads. Please follow the `Distributed Workloads` [Quick-Start](https://github.com/opendatahub-io/distributed-workloads/blob/main/Quick-Start.md) for installation.
+
 
 #### Steps
 
-- Install kuberay operator from [link](https://docs.ray.io/en/latest/cluster/kubernetes/getting-started.html#deploying-the-kuberay-operator)
-- Submit ray cluster to MCAD as appwrapper using the config file `aw-raycluster.yaml` present in the `config` directory using command `kubectl create -f aw-raycluster.yaml`
-- Check the status of the appwrapper using command `kubectl describe appwrapper <your-appwrapper-name>`
-- Check running pods using command `kubectl get pods -n <your-name-space>`
+
+- Submit the RayCluster custom resource to MCAD as AppWrapper using the [aw-raycluster.yaml](doc/usage/examples/kuberay/config/aw-raycluster.yaml) exmaple:
+    ```bash
+    kubectl create -f doc/usage/examples/kuberay/config/aw-raycluster.yaml
+    ```
+- Check the status of the AppWrapper custom resource using command
+    ```bash
+    kubectl describe appwrapper raycluster-complete -n default
+    ```
+- Check the raycluster status is ready using command
+    ```bash
+    kubectl get raycluster -n default
+    ```
+    Expect:
+    ``````
+    NAME                  DESIRED WORKERS   AVAILABLE WORKERS   STATUS   AGE
+    raycluster-complete   1                 1                   ready    6m45s
+    ```

--- a/doc/usage/examples/kuberay/kuberay-mcad.md
+++ b/doc/usage/examples/kuberay/kuberay-mcad.md
@@ -4,7 +4,7 @@ This integration will help in queuing on [kuberay](https://github.com/ray-projec
 
 #### Prerequisites
 
-- Kubernetes(see [KinD](https://helm.sh/docs/intro/install/)) or Openshift cluster(see [OpenShift Local](https://developers.redhat.com/products/openshift-local/overview))
+- Kubernetes(see [KinD](https://kind.sigs.k8s.io/)) or Openshift cluster(see [OpenShift Local](https://developers.redhat.com/products/openshift-local/overview))
 - Kubernetes client tools such as [kubectl](https://kubernetes.io/docs/tasks/tools/) or [OpenShift CLI](https://docs.openshift.com/container-platform/4.13/cli_reference/openshift_cli/getting-started-cli.html)
 - [Helm](https://helm.sh/docs/intro/install/)
 - Install MCAD and KubeRay operators:


### PR DESCRIPTION
# Issue link
closes #583 

# What changes have been made
- update doc/usage/examples/kuberay/kuberay-mcad.md
- remove raycluster-autoscaler example because currently mcad does not support

# Verification steps
Follow the instruction in the modified `doc/usage/examples/kuberay/kuberay-mcad.md`  file

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

This PR should be updated with the [issue](https://github.com/ray-project/kuberay/issues/1327)
/cc @anishasthana @kevin85421 