### PR TITLE
refactor updatequeuejob thread logic in informer

### DIFF
--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -1706,7 +1706,7 @@ func (cc *XController) updateQueueJob(oldObj, newObj interface{}) {
 						latestAw, exists, err := cc.appwrapperInformer.Informer().GetStore().GetByKey(key)
 						if err == nil && exists {
 							// Enqueue the latest copy of the AW.
-							if (newQJ.Status.State != arbv1.AppWrapperStateCompleted || newQJ.Status.State != arbv1.AppWrapperStateFailed) && hasCompletionStatus {
+							if (newQJ.Status.State != arbv1.AppWrapperStateCompleted && newQJ.Status.State != arbv1.AppWrapperStateFailed) && hasCompletionStatus {
 								cc.UpdateQueueJobs(latestAw.(*arbv1.AppWrapper))
 								klog.V(2).Infof("[Informer-updateQJ] Finished requeing AW to determine completion status")
 							}

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -1704,7 +1704,7 @@ func (cc *XController) updateQueueJob(oldObj, newObj interface{}) {
 					for {
 						time.Sleep(requeueInterval)
 						latestAw, exists, err := cc.appwrapperInformer.Informer().GetStore().GetByKey(key)
-						if latestAw.(*arbv1.AppWrapper).Status.State == arbv1.AppWrapperStateCompleted || latestAw.(arbv1.AppWrapper).Status.State == arbv1.AppWrapperStateFailed || latestAw.(arbv1.AppWrapper).Status.State == arbv1.AppWrapperStateDeleted || !exists {
+						if latestAw.(*arbv1.AppWrapper).Status.State != arbv1.AppWrapperStateActive && latestAw.(*arbv1.AppWrapper).Status.State != arbv1.AppWrapperStateEnqueued && latestAw.(*arbv1.AppWrapper).Status.State != arbv1.AppWrapperStateRunningHoldCompletion || !exists {
 							klog.V(2).Infof("[Informer-updateQJ] Stopping requeue for AW %s with status %s", latestAw.(*arbv1.AppWrapper).Name, latestAw.(*arbv1.AppWrapper).Status.State)
 							break //Exit the loop
 						}

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -1704,7 +1704,7 @@ func (cc *XController) updateQueueJob(oldObj, newObj interface{}) {
 					for {
 						time.Sleep(requeueInterval)
 						latestAw, exists, err := cc.appwrapperInformer.Informer().GetStore().GetByKey(key)
-						if latestAw.(*arbv1.AppWrapper).Status.State == arbv1.AppWrapperStateCompleted || latestAw.(arbv1.AppWrapper).Status.State == arbv1.AppWrapperStateFailed || latestAw.(arbv1.AppWrapper).Status.State == arbv1.AppWrapperStateDeleted {
+						if latestAw.(*arbv1.AppWrapper).Status.State == arbv1.AppWrapperStateCompleted || latestAw.(arbv1.AppWrapper).Status.State == arbv1.AppWrapperStateFailed || latestAw.(arbv1.AppWrapper).Status.State == arbv1.AppWrapperStateDeleted || !exists {
 							klog.V(2).Infof("[Informer-updateQJ] Stopping requeue for AW %s with status %s", latestAw.(*arbv1.AppWrapper).Name, latestAw.(*arbv1.AppWrapper).Status.State)
 							break
 						}

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -1706,7 +1706,7 @@ func (cc *XController) updateQueueJob(oldObj, newObj interface{}) {
 						latestAw, exists, err := cc.appwrapperInformer.Informer().GetStore().GetByKey(key)
 						if latestAw.(*arbv1.AppWrapper).Status.State == arbv1.AppWrapperStateCompleted || latestAw.(arbv1.AppWrapper).Status.State == arbv1.AppWrapperStateFailed || latestAw.(arbv1.AppWrapper).Status.State == arbv1.AppWrapperStateDeleted || !exists {
 							klog.V(2).Infof("[Informer-updateQJ] Stopping requeue for AW %s with status %s", latestAw.(*arbv1.AppWrapper).Name, latestAw.(*arbv1.AppWrapper).Status.State)
-							break
+							break //Exit the loop
 						}
 						if err == nil && exists {
 							// Enqueue the latest copy of the AW.

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -1704,6 +1704,10 @@ func (cc *XController) updateQueueJob(oldObj, newObj interface{}) {
 					for {
 						time.Sleep(requeueInterval)
 						latestAw, exists, err := cc.appwrapperInformer.Informer().GetStore().GetByKey(key)
+						if latestAw.(*arbv1.AppWrapper).Status.State == arbv1.AppWrapperStateCompleted || latestAw.(arbv1.AppWrapper).Status.State == arbv1.AppWrapperStateFailed || latestAw.(arbv1.AppWrapper).Status.State == arbv1.AppWrapperStateDeleted {
+							klog.V(2).Infof("[Informer-updateQJ] Stopping requeue for AW %s with status %s", latestAw.(*arbv1.AppWrapper).Name, latestAw.(*arbv1.AppWrapper).Status.State)
+							break
+						}
 						if err == nil && exists {
 							// Enqueue the latest copy of the AW.
 							if (newQJ.Status.State != arbv1.AppWrapperStateCompleted && newQJ.Status.State != arbv1.AppWrapperStateFailed) && hasCompletionStatus {

--- a/pkg/controller/queuejob/queuejob_controller_ex.go
+++ b/pkg/controller/queuejob/queuejob_controller_ex.go
@@ -1695,7 +1695,7 @@ func (cc *XController) updateQueueJob(oldObj, newObj interface{}) {
 			}
 		}
 		//updatequeuejobs now runs as a part of informer machinery. optimization here is to not use etcd to pullout submitted AWs and operate
-		//on slate Aws
+		//on stale AWs. This has potential to improve performance at scale.
 		if newQJ.Status.State != arbv1.AppWrapperStateCompleted && newQJ.Status.State != arbv1.AppWrapperStateFailed && newQJ.Status.State != "" {
 			requeueInterval := 30 * time.Second
 			key, err := cache.MetaNamespaceKeyFunc(newQJ)

--- a/test/e2e/queue.go
+++ b/test/e2e/queue.go
@@ -141,12 +141,12 @@ var _ = Describe("AppWrapper E2E Test", func() {
 		aw := createJobAWWithInitContainer(context, "aw-job-3-init-container-1", 60, "exponential", 0)
 		appwrappers = append(appwrappers, aw)
 
-		err := waitAWPodsCompleted(context, aw, 12*time.Minute) // This test waits for 12 minutes to make sure all PODs complete
+		err := waitAWPodsCompleted(context, aw, 14*time.Minute) // This test waits for 14 minutes to make sure all PODs complete
 		Expect(err).NotTo(HaveOccurred(), "Waiting for the pods to be completed")
 	})
 
 	It("MCAD CPU Requeuing - Deletion After Maximum Requeuing Times Test", func() {
-		fmt.Fprintf(os.Stdout, "[e2e] MCAD CPU Requeuing Test - Started.\n")
+		fmt.Fprintf(os.Stdout, "[e2e] MCAD CPU Requeuing - Deletion After Maximum Requeuing Times Test - Started.\n")
 
 		context := initTestContext()
 		var appwrappers []*arbv1.AppWrapper
@@ -513,7 +513,7 @@ var _ = Describe("AppWrapper E2E Test", func() {
 		defer cleanupTestObjectsPtr(context, appwrappersPtr)
 
 		// This should fill up the worker node and most of the master node
-		aw := createDeploymentAWwith550CPU(context, appendRandomString("aw-deployment-2-550cpu"))
+		aw := createDeploymentAWwith550CPU(context, appendRandomString("aw-deployment-2-550cpu-2"))
 		appwrappers = append(appwrappers, aw)
 
 		err := waitAWPodsReady(context, aw)


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
#602 
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Removed independent updatequeuejob thread that looped through all the AWs in etcd to determine completion status and update pod count. the fix adds updatequeuejob logic to the informer's machinery which has promise to improve MCADs updatestatus performance at scale.
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
I have verified that the fix works manually.
## Checks
- [X] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change
