### PR TITLE
Add make target that simplifies build-push-deployment to cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,13 @@ ifneq ($(TAG:release-v%=%),$(TAG))
 endif
 endif
 
+# easy-deploy can be used for building and pushing a custom image of MCAD and deploying it on your K8s cluster for development.
+# Example: "make easy-deploy TAG=<image tag> USERNAME=<quay.io username>"
+easy-deploy: images-podman
+	podman tag localhost/mcad-controller:${TAG} quay.io/${USERNAME}/mcad-controller:${TAG}
+	podman push quay.io/${USERNAME}/mcad-controller:${TAG}
+	cd deployment && helm install mcad-controller mcad-controller --namespace kube-system --wait --set image.repository=quay.io/${USERNAME}/mcad-controller --set image.tag=${TAG}
+
 run-test:
 	$(info Running unit tests...)
 	go test -v -coverprofile cover.out -race -parallel 8  ./pkg/...

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Follow the [build instructions here](./doc/build/build.md) to build the Multi-Cl
 
 Refer to [deployment instructions here](./doc/deploy/deployment.md) on how to deploy the `multi-cluster-app-dispatcher` as a controller in Kubernetes.
 
+Alternatively, for a quick deployment, you can use the `easy-deploy` make target to build, push, and deploy your custom image of MCAD on your Kubernetes cluster:
+```
+make easy-deploy TAG=<image tag> USERNAME=<quay.io username>
+```
+Note: Ensure you are logged into your quay.io account on your local machine, and your kubeconfig is pointing to the cluster you want to deploy MCAD on.
 
 ## Release Process
 

--- a/doc/deploy/deployment.md
+++ b/doc/deploy/deployment.md
@@ -142,6 +142,15 @@ For example:
 ```
 helm install <release-name> mcad-controller --namespace kube-system --wait --set image.repository=tonghoon --set image.tag=both --set configMap.name=mcad-deployer --set configMap.dispatcherMode='"true"' --set configMap.agentConfigs=agent101config:uncordon --set volumes.hostPath=/etc/kubernetes
 ```
+
+##### Example 4 
+Use the `easy-deploy` make target to build, push, and deploy your custom image of MCAD on your Kubernetes cluster:
+
+```
+make easy-deploy TAG=<image tag> USERNAME=<quay.io username>
+```
+Note: This assumes you are logged into your quay.io account on your local machine, and your kubeconfig is pointing to the cluster you want to deploy MCAD on.
+
 ### Chart configuration
 
 The following table lists the configurable parameters of the helm chart and their default values.


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Closes #638 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
The `easy-deploy` make target can be used for building and pushing a custom image of MCAD and deploying it on your K8s cluster for development.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Example: `make easy-deploy TAG=yourtag USERNAME=rh_ee_jdoe`


## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Manual tests

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->