### PR TITLE
Enhance MCAD Logs and fix naming consistency

### DIFF
--- a/pkg/controller/queuejob/scheduling_queue.go
+++ b/pkg/controller/queuejob/scheduling_queue.go
@@ -161,7 +161,7 @@ func (p *PriorityQueue) MoveToActiveQueueIfExists(aw *qjobv1.AppWrapper) error {
 		p.unschedulableQ.Delete(aw)
 		err := p.activeQ.AddIfNotPresent(aw)
 		if err != nil {
-			klog.Errorf("[MoveToActiveQueueIfExists] Error adding AW %v to the scheduling queue: %v\n", aw.Name, err)
+			klog.Errorf("[MoveToActiveQueueIfExists] Error adding AW %s/%s to the scheduling queue: %v\n", aw.Namespace, aw.Name, err)
 		}
 		p.cond.Broadcast()
 		return err
@@ -176,10 +176,10 @@ func (p *PriorityQueue) Add(qj *qjobv1.AppWrapper) error {
 	defer p.lock.Unlock()
 	err := p.activeQ.Add(qj)
 	if err != nil {
-		klog.Errorf("Error adding QJ %v to the scheduling queue: %v", qj.Name, err)
+		klog.Errorf("Error adding QJ %s/%s to the scheduling queue: %v", qj.Namespace, qj.Name, err)
 	} else {
 		if p.unschedulableQ.Get(qj) != nil {
-			klog.Errorf("Error: QJ %v is already in the unschedulable queue.", qj.Name)
+			klog.Errorf("Error: QJ %s/%s is already in the unschedulable queue.", qj.Namespace, qj.Name)
 			p.unschedulableQ.Delete(qj)
 		}
 		p.cond.Broadcast()
@@ -201,7 +201,7 @@ func (p *PriorityQueue) AddIfNotPresent(qj *qjobv1.AppWrapper) error {
 	}
 	err := p.activeQ.Add(qj)
 	if err != nil {
-		klog.Errorf("Error adding pod %v to the scheduling queue: %v", qj.Name, err)
+		klog.Errorf("Error adding pod %s/%s to the scheduling queue: %v", qj.Namespace, qj.Name, err)
 	} else {
 		p.cond.Broadcast()
 	}

--- a/pkg/controller/queuejobdispatch/queuejobagent.go
+++ b/pkg/controller/queuejobdispatch/queuejobagent.go
@@ -129,7 +129,7 @@ func (cc *JobClusterAgent) addQueueJob(obj interface{}) {
 		klog.Errorf("obj is not AppWrapper")
 		return
 	}
-	klog.V(10).Infof("[TTime]: %s Adding New Job: %s to EventQ\n", time.Now().String(), qj.Name)
+	klog.V(10).Infof("[TTime]: %s Adding New Job: %s/%s to EventQ\n", time.Now().String(), qj.Namespace, qj.Name)
 	cc.agentEventQueue.Add(qj)
 }
 
@@ -139,7 +139,7 @@ func (cc *JobClusterAgent) updateQueueJob(oldObj, newObj interface{}) {
 		klog.Errorf("newObj is not AppWrapper")
 		return
 	}
-	klog.V(10).Infof("[TTime]: %s Adding Update Job: %s to EventQ\n", time.Now().String(), newQJ.Name)
+	klog.V(10).Infof("[TTime]: %s Adding Update Job: %s/%s to EventQ\n", time.Now().String(), newQJ.Namespace, newQJ.Name)
 	cc.agentEventQueue.Add(newQJ)
 }
 
@@ -149,7 +149,7 @@ func (cc *JobClusterAgent) deleteQueueJob(obj interface{}) {
 		klog.Errorf("obj is not AppWrapper")
 		return
 	}
-	klog.V(10).Infof("[TTime]: %s Adding Delete Job: %s to EventQ\n", time.Now().String(), qj.Name)
+	klog.V(10).Infof("[TTime]: %s Adding Delete Job: %s/%s to EventQ\n", time.Now().String(), qj.Namespace, qj.Name)
 	cc.agentEventQueue.Add(qj)
 }
 
@@ -160,7 +160,7 @@ func (qa *JobClusterAgent) Run(stopCh <-chan struct{}) {
 
 func (qa *JobClusterAgent) DeleteJob(ctx context.Context, cqj *arbv1.AppWrapper) {
 	qj_temp := cqj.DeepCopy()
-	klog.V(2).Infof("[Dispatcher: Agent] Request deletion of XQJ %s to Agent %s\n", qj_temp.Name, qa.AgentId)
+	klog.V(2).Infof("[Dispatcher: Agent] Request deletion of XQJ %s/%s to Agent %s\n", qj_temp.Namespace, qj_temp.Name, qa.AgentId)
 	qa.queuejobclients.WorkloadV1beta1().AppWrappers(qj_temp.Namespace).Delete(ctx, qj_temp.Name, metav1.DeleteOptions{})
 }
 
@@ -182,7 +182,7 @@ func (qa *JobClusterAgent) CreateJob(ctx context.Context, cqj *arbv1.AppWrapper)
 	}
 	agent_qj.Labels["IsDispatched"] = "true"
 
-	klog.V(2).Infof("[Dispatcher: Agent] Create XQJ: %s (Status: %+v) in Agent %s\n", agent_qj.Name, agent_qj.Status, qa.AgentId)
+	klog.V(2).Infof("[Dispatcher: Agent] Create XQJ: %s/%s (Status: %+v) in Agent %s\n", agent_qj.Namespace, agent_qj.Name, agent_qj.Status, qa.AgentId)
 	qa.queuejobclients.WorkloadV1beta1().AppWrappers(agent_qj.Namespace).Create(ctx, agent_qj, metav1.CreateOptions{})
 }
 

--- a/pkg/controller/queuejobresources/genericresource/genericresource.go
+++ b/pkg/controller/queuejobresources/genericresource/genericresource.go
@@ -199,7 +199,7 @@ func (gr *GenericResources) SyncQueueJob(aw *arbv1.AppWrapper, awr *arbv1.AppWra
 		if pErr := recover(); pErr != nil {
 			klog.Errorf("[SyncQueueJob] Panic occurred: %v, stacktrace: %s", pErr, string(debug.Stack()))
 		}
-		klog.V(4).Infof("Finished syncing AppWrapper job resource %s (%v)", aw.Name, time.Now().Sub(startTime))
+		klog.V(4).Infof("Finished syncing AppWrapper job resource %s/%s (%v)", aw.Namespace, aw.Name, time.Now().Sub(startTime))
 	}()
 
 	namespaced := true

--- a/pkg/controller/quota/quotaforestmanager/qm_lib_backend_with_quotasubt_mgr.go
+++ b/pkg/controller/quota/quotaforestmanager/qm_lib_backend_with_quotasubt_mgr.go
@@ -641,7 +641,7 @@ func (qm *QuotaManager) Release(aw *arbv1.AppWrapper) bool {
 	// Handle uninitialized quota manager
 	if qm.quotaManagerBackend == nil {
 		klog.Errorf("[Release] No quota manager backend exists, Quota release %s/%s fails quota by default.",
-			aw.Name, aw.Namespace)
+			aw.Namespace, aw.Name)
 		return false
 	}
 

--- a/pkg/controller/quota/quotaforestmanager/qm_lib_backend_with_quotasubt_mgr/quotasubtmgr/event_handlers.go
+++ b/pkg/controller/quota/quotaforestmanager/qm_lib_backend_with_quotasubt_mgr/quotasubtmgr/event_handlers.go
@@ -33,7 +33,7 @@ func (qstm *QuotaSubtreeManager) addQST(obj interface{}) {
 	qstm.qstMap[qst.Namespace+"/"+qst.Name] = qst
 	qstm.setQuotasubtreeChanged()
 	qstm.qstMutex.Unlock()
-	klog.V(4).Infof("[addQST] Add complete for: %s/%s", qst.Name, qst.Namespace)
+	klog.V(4).Infof("[addQST] Add complete for: %s/%s", qst.Namespace, qst.Name)
 }
 
 func (qstm *QuotaSubtreeManager) updateQST(oldObj, newObj interface{}) {
@@ -65,7 +65,7 @@ func (qstm *QuotaSubtreeManager) updateQST(oldObj, newObj interface{}) {
 		qstm.setQuotasubtreeChanged()
 		qstm.qstMutex.Unlock()
 	}
-	klog.V(4).Infof("[updateQST] Update complete for: %s/%s", newQST.Name, newQST.Namespace)
+	klog.V(4).Infof("[updateQST] Update complete for: %s/%s", newQST.Namespace, newQST.Name)
 }
 
 func (qstm *QuotaSubtreeManager) deleteQST(obj interface{}) {
@@ -79,5 +79,5 @@ func (qstm *QuotaSubtreeManager) deleteQST(obj interface{}) {
 
 	delete(qstm.qstMap, string(qst.UID))
 	delete(qstm.qstMap, qst.Namespace+"/"+qst.Name)
-	klog.V(4).Infof("[deleteQST] Delete complete for: %s/%s", qst.Name, qst.Namespace)
+	klog.V(4).Infof("[deleteQST] Delete complete for: %s/%s", qst.Namespace, qst.Name)
 }


### PR DESCRIPTION
# Issue link
Resolves #644

### Motivation
In the scenario where we want to create an AW in two different namespaces but with the same name, it is important to know which AppWrapper the logs are referring to.

Previously: 
- There are a number of instances where the logs only provide the `name` of the AppWrapper or Job, instead of following the most used pattern of `namespace/name` as done i.e., [here](https://github.com/project-codeflare/multi-cluster-app-dispatcher/blob/b445015360abf09bf11bb1c7024068005a1a8a87/pkg/controller/queuejob/queuejob_controller_ex.go#L595). 

- There are a couple of places where the logs display `name/name`, such as [here](https://github.com/project-codeflare/multi-cluster-app-dispatcher/blob/b445015360abf09bf11bb1c7024068005a1a8a87/pkg/controller/queuejob/queuejob_controller_ex.go#L1407).

- A few places have the `name/namespace` pattern, which can be inconsistent when looking/searching through the logs.

- Few instances where i.e., `qj.Name` is provided in [the Info log](https://github.com/project-codeflare/multi-cluster-app-dispatcher/blob/b445015360abf09bf11bb1c7024068005a1a8a87/pkg/controller/queuejob/queuejob_controller_ex.go#L1662) but not used.

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
- The logs now consistently refer to the AppWrappers or Jobs in the form of `namespace/name`.
- Typo fixes.



# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
- With MCAD running, create an AppWrapper, and check MCAD logs for `<namespace/name>` of your AW.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests