### PR TITLE
Post notification about operator upgrade failure to a Slack channel

### DIFF
--- a/.github/workflows/update-codeflare-operator.yml
+++ b/.github/workflows/update-codeflare-operator.yml
@@ -57,3 +57,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.CODEFLARE_MACHINE_ACCOUNT_TOKEN }}
         working-directory: operator
+
+      - name: Post notification about failure to a Slack channel
+        if: failure()
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          channel-id: "codeflare-nightlies"
+          slack-message: "MCAD to CodeFlare operator upgrade action failed, <https://github.com/project-codeflare/multi-cluster-app-dispatcher/actions/workflows/update-codeflare-operator.yml|View workflow runs>"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
N/A

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
When CodeFlare operator upgrade workflow fails then a Slack notification is sent to `codeflare-nightlies` channel to notify people about the failure, so it can be addressed.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
N/A

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->