### PR TITLE
MCAD deployment in custom namespace

### DIFF
--- a/deployment/mcad-controller/templates/configmap.yaml
+++ b/deployment/mcad-controller/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.configMap.name }}
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 data:
   QUOTA_ENABLED: {{ .Values.configMap.quotaEnabled }}
   DISPATCHER_MODE: {{ .Values.configMap.dispatcherMode }}

--- a/deployment/mcad-controller/templates/deployment.yaml
+++ b/deployment/mcad-controller/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: custom-metrics-apiserver
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 spec:
   ports:
   - name: https
@@ -40,7 +40,7 @@ metadata:
 spec:
   service:
     name: custom-metrics-apiserver
-    namespace: kube-system
+    namespace: {{ .Values.namespace }}
   group: external.metrics.k8s.io
   version: v1beta1
   insecureSkipTLSVerify: true
@@ -135,7 +135,7 @@ metadata:
   labels:
     wdc.ibm.com/ownership: admin
   name: {{ .Values.serviceAccount }}
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 #{{ end }}
 ---
 #{{ if .Values.serviceAccount }}
@@ -154,7 +154,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount }}
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -171,7 +171,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount }}
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -188,14 +188,14 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount }}
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 #{{ end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.deploymentName }}
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     app: custom-metrics-apiserver

--- a/deployment/mcad-controller/templates/imageSecret.yaml
+++ b/deployment/mcad-controller/templates/imageSecret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.imagePullSecret.name }}
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "imagePullSecret" . }}


### PR DESCRIPTION
# What changes have been made

Installing MCAD always happens in the `kube-system` namespace. This update allows users to specify the namespace they want to use for the deployment.

# Verification steps

Create a namespace called `mcad` and deployed MCAD there using the `helm` chart and `--set namespace="mcad"`.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change