### PR TITLE
Force creation of generic items into AppWrapper deployment namespace

### DIFF
--- a/pkg/controller/queuejobresources/genericresource/genericresource.go
+++ b/pkg/controller/queuejobresources/genericresource/genericresource.go
@@ -273,7 +273,7 @@ func (gr *GenericResources) SyncQueueJob(aw *arbv1.AppWrapper, awr *arbv1.AppWra
 	ownerRef := metav1.NewControllerRef(aw, appWrapperKind)
 	unstruct.Object = blob.(map[string]interface{}) // set object to the content of the blob after Unmarshalling
 	unstruct.SetOwnerReferences(append(unstruct.GetOwnerReferences(), *ownerRef))
-	namespace := "default"
+	namespace := aw.Namespace // create resource in AppWrapper namespace
 	name := ""
 	if md, ok := unstruct.Object["metadata"]; ok {
 
@@ -282,7 +282,9 @@ func (gr *GenericResources) SyncQueueJob(aw *arbv1.AppWrapper, awr *arbv1.AppWra
 			name = objectName.(string)
 		}
 		if objectns, ok := metadata["namespace"]; ok {
-			namespace = objectns.(string)
+			if objectns.(string) != namespace {
+				return []*v1.Pod{}, fmt.Errorf("[SyncQueueJob] resource namespace \"%s\" is different from AppWrapper namespace \"%s\"", objectns.(string), namespace)
+			}
 		}
 	}
 	labels := map[string]string{}

--- a/pkg/controller/queuejobresources/genericresource/genericresource.go
+++ b/pkg/controller/queuejobresources/genericresource/genericresource.go
@@ -150,7 +150,7 @@ func (gr *GenericResources) Cleanup(aw *arbv1.AppWrapper, awr *arbv1.AppWrapperG
 	}
 
 	unstruct.Object = blob.(map[string]interface{}) // set object to the content of the blob after Unmarshalling
-	namespace := ""
+	namespace := aw.Namespace                       // only delete resources from AppWrapper namespace
 	if md, ok := unstruct.Object["metadata"]; ok {
 
 		metadata := md.(map[string]interface{})
@@ -158,13 +158,16 @@ func (gr *GenericResources) Cleanup(aw *arbv1.AppWrapper, awr *arbv1.AppWrapperG
 			name = objectName.(string)
 		}
 		if objectns, ok := metadata["namespace"]; ok {
-			namespace = objectns.(string)
+			if objectns.(string) != namespace {
+				err := fmt.Errorf("[Cleanup] resource namespace \"%s\" is different from AppWrapper namespace \"%s\"", objectns.(string), namespace)
+				return name, gvk, err
+			}
 		}
 	}
 
-	// Get the resource to see if it exists
+	// Get the resource to see if it exists in the AppWrapper namespace
 	labelSelector := fmt.Sprintf("%s=%s, %s=%s", appwrapperJobName, aw.Name, resourceName, unstruct.GetName())
-	inEtcd, err := dclient.Resource(rsrc).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
+	inEtcd, err := dclient.Resource(rsrc).Namespace(aw.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
 		return name, gvk, err
 	}
@@ -273,7 +276,7 @@ func (gr *GenericResources) SyncQueueJob(aw *arbv1.AppWrapper, awr *arbv1.AppWra
 	ownerRef := metav1.NewControllerRef(aw, appWrapperKind)
 	unstruct.Object = blob.(map[string]interface{}) // set object to the content of the blob after Unmarshalling
 	unstruct.SetOwnerReferences(append(unstruct.GetOwnerReferences(), *ownerRef))
-	namespace := aw.Namespace // create resource in AppWrapper namespace
+	namespace := aw.Namespace // only create resources in AppWrapper namespace
 	name := ""
 	if md, ok := unstruct.Object["metadata"]; ok {
 
@@ -283,7 +286,8 @@ func (gr *GenericResources) SyncQueueJob(aw *arbv1.AppWrapper, awr *arbv1.AppWra
 		}
 		if objectns, ok := metadata["namespace"]; ok {
 			if objectns.(string) != namespace {
-				return []*v1.Pod{}, fmt.Errorf("[SyncQueueJob] resource namespace \"%s\" is different from AppWrapper namespace \"%s\"", objectns.(string), namespace)
+				err := fmt.Errorf("[SyncQueueJob] resource namespace \"%s\" is different from AppWrapper namespace \"%s\"", objectns.(string), namespace)
+				return []*v1.Pod{}, err
 			}
 		}
 	}


### PR DESCRIPTION
This PR makes sure that generic items are created in the same namespace as the AppWrapper. If the metadata of the generic item explicitly specifies a namespace that is different from the AppWrapper deployment namespace, an error message is generated to report the discrepancy and the resource creation fails. If the specified namespace is equal to the AppWrapper namespace or if no explicit namespace is specified then the creation can process in the AppWrapper namespace.

This PR does not affect the creation of cluster scoped resources, which was already prohibited.

This PR modifies MCAD's behavior when resources do not specify a namespace. They used to be deployed in the `default` namespace irrespective of the AppWrapper namespace. Now they will be deployed in the AppWrapper namespace instead. Alternatively, we could check the namespace without changing the existing behavior. In the long term though, if the deployment namespace can only be the appwrapper namespace, it does not make much sense to require the namespace in the resource definition, i.e., interpret the absence of a namespace as the `default` namespace.