### PR TITLE
Forceful deletion of remaining pods after cleanup

### DIFF
--- a/config/crd/bases/workload.codeflare.dev_appwrappers.yaml
+++ b/config/crd/bases/workload.codeflare.dev_appwrappers.yaml
@@ -161,6 +161,13 @@ spec:
                       check should happen, and if requeuing has reached its maximum
                       number of times.
                     properties:
+                      forcefulDeletionAfterSeconds:
+                        default: 0
+                        description: Enable forceful deletion of generic items and
+                          pods with the AppWrapper label after specified seconds.
+                          This may be necesary to prevent redeployment of generic
+                          items that create pods that were not correctly deleted.
+                        type: integer
                       growthType:
                         default: exponential
                         description: Growth strategy to increase the waiting time

--- a/config/crd/bases/workload.codeflare.dev_schedulingspecs.yaml
+++ b/config/crd/bases/workload.codeflare.dev_schedulingspecs.yaml
@@ -58,6 +58,13 @@ spec:
                   time. Values in this field control how often the pod check should
                   happen, and if requeuing has reached its maximum number of times.
                 properties:
+                  forcefulDeletionAfterSeconds:
+                    default: 0
+                    description: Enable forceful deletion of generic items and pods
+                      with the AppWrapper label after specified seconds. This may
+                      be necesary to prevent redeployment of generic items that create
+                      pods that were not correctly deleted.
+                    type: integer
                   growthType:
                     default: exponential
                     description: Growth strategy to increase the waiting time between

--- a/deployment/mcad-controller/crds/workload.codeflare.dev_appwrappers.yaml
+++ b/deployment/mcad-controller/crds/workload.codeflare.dev_appwrappers.yaml
@@ -161,6 +161,13 @@ spec:
                       check should happen, and if requeuing has reached its maximum
                       number of times.
                     properties:
+                      forcefulDeletionAfterSeconds:
+                        default: 0
+                        description: Enable forceful deletion of generic items and
+                          pods with the AppWrapper label after specified seconds.
+                          This may be necesary to prevent redeployment of generic
+                          items that create pods that were not correctly deleted.
+                        type: integer
                       growthType:
                         default: exponential
                         description: Growth strategy to increase the waiting time

--- a/deployment/mcad-controller/crds/workload.codeflare.dev_schedulingspecs.yaml
+++ b/deployment/mcad-controller/crds/workload.codeflare.dev_schedulingspecs.yaml
@@ -58,6 +58,13 @@ spec:
                   time. Values in this field control how often the pod check should
                   happen, and if requeuing has reached its maximum number of times.
                 properties:
+                  forcefulDeletionAfterSeconds:
+                    default: 0
+                    description: Enable forceful deletion of generic items and pods
+                      with the AppWrapper label after specified seconds. This may
+                      be necesary to prevent redeployment of generic items that create
+                      pods that were not correctly deleted.
+                    type: integer
                   growthType:
                     default: exponential
                     description: Growth strategy to increase the waiting time between

--- a/pkg/apis/controller/v1beta1/schedulingspec.go
+++ b/pkg/apis/controller/v1beta1/schedulingspec.go
@@ -72,6 +72,10 @@ type RequeuingTemplate struct {
 	// items are stopped and removed from the cluster (AppWrapper remains deployed).
 	// +kubebuilder:default=0
 	MaxNumRequeuings int `json:"maxNumRequeuings,omitempty" protobuf:"bytes,6,rep,name=maxNumRequeuings"`
+    // Enable forceful deletion of generic items and pods with the AppWrapper label after specified seconds.
+    // This may be necesary to prevent redeployment of generic items that create pods that were not correctly deleted.
+    // +kubebuilder:default=0
+    ForcefulDeletionAfterSeconds int `json:"forcefulDeletionAfterSeconds,omitempty" protobuf:"bytes,7,rep,name=forcefulDeletionAfterSeconds"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
# Issue link

#599 

# What changes have been made

This version of the code allows users to provide a *termination* time that MCAD will use to wait before it forcefully deletes any remaining pods in the system. A cleanup is done first like it has always been done, but if there are still pods left after the wait time, they are forcefully deleted.

# Verification steps

Ran code with AppWrapped pods that have a long `terminationGracePeriodSeconds` and triggered preemption by deleting one of the pods so `minAvailable` is violated. Before requeuing, this version deletes ALL pods that are not cleaned up.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change