### PR TITLE
add: caching for Discovery Client

### DIFF
--- a/cmd/kar-controllers/app/discovery/discovery.go
+++ b/cmd/kar-controllers/app/discovery/discovery.go
@@ -1,0 +1,39 @@
+package discovery
+
+import (
+	"k8s.io/klog/v2"
+	"time"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+)
+
+var GlobalCachedDiscoveryClient discovery.CachedDiscoveryInterface
+
+func InitializeGlobalDiscoveryClient(config *rest.Config) error {
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return err
+	}
+	GlobalCachedDiscoveryClient = memory.NewMemCacheClient(discoveryClient)
+	
+	go startDiscoveryRefreshTicker()
+	
+	return nil
+}
+
+func RefreshDiscoveryCache() {
+	klog.Infof("Invalidating discovery cache")
+	GlobalCachedDiscoveryClient.Invalidate()
+}
+
+func startDiscoveryRefreshTicker() {
+    ticker := time.NewTicker(5 * time.Hour)
+    for {
+        select {
+        case <-ticker.C:
+            RefreshDiscoveryCache()
+        }
+    }
+}

--- a/cmd/kar-controllers/app/server.go
+++ b/cmd/kar-controllers/app/server.go
@@ -18,6 +18,8 @@ package app
 
 import (
 	"net/http"
+	"k8s.io/klog/v2"
+	"github.com/project-codeflare/multi-cluster-app-dispatcher/cmd/kar-controllers/app/discovery"
 	"strings"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -60,6 +62,12 @@ func Run(opt *options.ServerOption) error {
 	extConfig := &config.MCADConfigurationExtended{
 		Dispatcher:   pointer.Bool(opt.Dispatcher),
 		AgentConfigs: strings.Split(opt.AgentConfigs, ","),
+	}
+
+	if err = discovery.InitializeGlobalDiscoveryClient(restConfig); err != nil {
+		klog.Errorf("Error initializing global discovery client: %s", err)
+	} else {
+		klog.Infof("Initializing global discovery client")
 	}
 
 	jobctrl := queuejob.NewJobController(restConfig, mcadConfig, extConfig)

--- a/pkg/controller/queuejobresources/genericresource/genericresource.go
+++ b/pkg/controller/queuejobresources/genericresource/genericresource.go
@@ -24,7 +24,8 @@ import (
 	"runtime/debug"
 	"strings"
 	"time"
-
+ 
+	discoveryCache "github.com/project-codeflare/multi-cluster-app-dispatcher/cmd/kar-controllers/app/discovery"
 	arbv1 "github.com/project-codeflare/multi-cluster-app-dispatcher/pkg/apis/controller/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -86,8 +87,8 @@ func (gr *GenericResources) Cleanup(aw *arbv1.AppWrapper, awr *arbv1.AppWrapperG
 	name := ""
 
 	namespaced := true
-	// todo:DELETEME	dd := common.KubeClient.Discovery()
-	dd := gr.clients.Discovery()
+
+	dd := discoveryCache.GlobalCachedDiscoveryClient
 	apigroups, err := restmapper.GetAPIGroupResources(dd)
 	if err != nil {
 		klog.Errorf("[Cleanup] Error getting API resources, err=%#v", err)
@@ -206,8 +207,7 @@ func (gr *GenericResources) SyncQueueJob(aw *arbv1.AppWrapper, awr *arbv1.AppWra
 	}()
 
 	namespaced := true
-	// todo:DELETEME	dd := common.KubeClient.Discovery()
-	dd := gr.clients.Discovery()
+	dd := discoveryCache.GlobalCachedDiscoveryClient
 	apigroups, err := restmapper.GetAPIGroupResources(dd)
 	if err != nil {
 		klog.Errorf("Error getting API resources, err=%#v", err)
@@ -624,7 +624,7 @@ func getContainerResources(container v1.Container, replicas float64) *clustersta
 
 // returns status of an item present in etcd
 func (gr *GenericResources) IsItemCompleted(awgr *arbv1.AppWrapperGenericResource, namespace string, appwrapperName string, genericItemName string) (completed bool) {
-	dd := gr.clients.Discovery()
+	dd := discoveryCache.GlobalCachedDiscoveryClient
 	apigroups, err := restmapper.GetAPIGroupResources(dd)
 	if err != nil {
 		klog.Errorf("[IsItemCompleted] Error getting API resources, err=%#v", err)


### PR DESCRIPTION
# Issue link
closes https://github.com/project-codeflare/multi-cluster-app-dispatcher/issues/611

# What changes have been made
Adding a Discovery Client cache, which will reduce the calls to the Discovery Client, and prevent throttling. The cache is then refreshed by a ticker every 5 hours. 


## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->