### PR TITLE
add aggregating roles for ns admin and editor

### DIFF
--- a/deployment/mcad-controller/templates/deployment.yaml
+++ b/deployment/mcad-controller/templates/deployment.yaml
@@ -53,6 +53,54 @@ kind: ClusterRole
 metadata:
   annotations:
     rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: mcad-operator-clusterrole-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups:
+  - workload.codeflare.dev
+  resources:
+  - schedulingspecs
+  - appwrappers
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: mcad-operator-clusterrole-admin
+  labels:
+    rbac.authorization.kubernetes.io/aggregate-to-admin: "true"
+rules:
+- apiGroups:
+  - quota.codeflare.dev
+  resources:
+  - quotasubtrees
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
   name: system:controller:xqueuejob-controller
   labels:
     kubernetes.io/bootstrapping: rbac-defaults


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/RHOAIENG-2184

# What changes have been made
Added a cluster roles which aggregate to admin and editor roles

# Verification steps
Make sure unprivileged user can create AppWrappers in namespaces where they have editor or admin privileges

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->